### PR TITLE
feat: プロジェクト基盤のセットアップ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+.venv/
+venv/
+ENV/
+env/
+
+# Flask
+instance/
+.webassets-cache
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# dotenv
+.env
+.env.local

--- a/app.py
+++ b/app.py
@@ -1,0 +1,13 @@
+from flask import Flask, render_template
+
+app = Flask(__name__)
+
+
+@app.route('/')
+def index():
+    """メインページ"""
+    return render_template('index.html')
+
+
+if __name__ == '__main__':
+    app.run(debug=True, host='0.0.0.0', port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask==3.0.0
+python-dotenv==1.0.0

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>htmx Design System PoC</title>
+</head>
+<body>
+    <h1>htmx Design System PoC</h1>
+    <p>プロジェクト基盤のセットアップが完了しました。</p>
+</body>
+</html>


### PR DESCRIPTION
## 概要
htmx + デザインシステム PoC の基盤を構築しました。

## 変更内容
* Flask 3.0.0 と python-dotenv を requirements.txt に追加
* ディレクトリ構造を作成
  * `templates/` - Flask テンプレート
  * `static/` - 静的ファイル
  * `components/` - 再利用可能なコンポーネント
  * `partials/` - 部分テンプレート
* 基本的な Flask アプリケーション（app.py）を実装
  * メインページのルート設定
  * デバッグモード有効化
* 初期テンプレート（index.html）を作成
* .gitignore を追加（Python/Flask/IDE/OS 用）

## テスト
* Flask アプリのインポートが正常に動作することを確認
* uv を使用して依存関係をインストール可能なことを確認

## 関連 Issue
Closes #1