### PR TITLE
feat: Moleculesコンポーネントの実装

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,6 +18,12 @@ def atoms():
     return render_template('atoms.html')
 
 
+@app.route('/molecules')
+def molecules():
+    """Moleculesコンポーネントカタログ"""
+    return render_template('molecules.html')
+
+
 # htmx デモ用APIエンドポイント
 @app.route('/api/demo/message')
 def demo_message():
@@ -45,6 +51,84 @@ def validate_username():
         return '<p class="text-red-600">✗ このユーザー名は使用できません</p>'
 
     return '<p class="text-green-600">✓ このユーザー名は使用可能です</p>'
+
+
+@app.route('/api/demo/submit-form', methods=['POST'])
+def demo_submit_form():
+    """フォーム送信デモ"""
+    name = request.form.get('name', '')
+    message = request.form.get('message', '')
+
+    if not name or not message:
+        return '<div class="p-4 bg-red-50 rounded-md"><p class="text-red-600">すべてのフィールドを入力してください</p></div>'
+
+    return f'''
+    <div class="p-4 bg-green-50 rounded-md">
+        <p class="text-green-600 font-semibold mb-2">✓ フォームが正常に送信されました！</p>
+        <div class="text-sm text-gray-700 space-y-1">
+            <p><strong>名前:</strong> {name}</p>
+            <p><strong>メッセージ:</strong> {message}</p>
+        </div>
+    </div>
+    '''
+
+
+@app.route('/api/demo/product/<product_id>')
+def demo_product(product_id):
+    """商品詳細デモ"""
+    products = {
+        'a': {
+            'name': '商品 A',
+            'price': '¥1,980',
+            'description': '高品質な商品Aです。素晴らしい機能を備えています。',
+            'stock': '在庫あり',
+            'color': 'blue'
+        },
+        'b': {
+            'name': '商品 B',
+            'price': '¥2,980',
+            'description': 'プレミアム商品Bです。最高の体験を提供します。',
+            'stock': '残りわずか',
+            'color': 'purple'
+        },
+        'c': {
+            'name': '商品 C',
+            'price': '¥980',
+            'description': 'お手頃価格の商品Cです。コストパフォーマンスに優れています。',
+            'stock': '在庫あり',
+            'color': 'green'
+        }
+    }
+
+    product = products.get(product_id)
+    if not product:
+        return '<p class="text-red-600">商品が見つかりませんでした</p>'
+
+    color_map = {
+        'blue': 'bg-blue-100 text-blue-800',
+        'purple': 'bg-purple-100 text-purple-800',
+        'green': 'bg-green-100 text-green-800'
+    }
+    color_class = color_map.get(product['color'], 'bg-gray-100 text-gray-800')
+
+    return f'''
+    <div class="space-y-4">
+        <h3 class="text-2xl font-bold text-gray-900">{product['name']}</h3>
+        <div class="flex items-center gap-4">
+            <span class="text-3xl font-bold text-blue-600">{product['price']}</span>
+            <span class="px-3 py-1 {color_class} rounded-full text-sm font-medium">{product['stock']}</span>
+        </div>
+        <p class="text-gray-700">{product['description']}</p>
+        <div class="flex gap-3 pt-4">
+            <button class="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition">
+                カートに追加
+            </button>
+            <button class="px-6 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 transition">
+                お気に入り
+            </button>
+        </div>
+    </div>
+    '''
 
 
 if __name__ == '__main__':

--- a/components/molecules/card.html
+++ b/components/molecules/card.html
@@ -1,0 +1,67 @@
+{#
+  カードコンポーネント
+
+  パラメータ:
+  - title: カードタイトル
+  - description: カードの説明文
+  - image_url: カード画像のURL
+  - footer_content: フッターのコンテンツ（HTML）
+  - variant: カードのバリエーション (デフォルト: "default")
+    - "default": デフォルトカード
+    - "hover": ホバーエフェクト付き
+    - "clickable": クリック可能なカード
+  - hx_get: htmx GET リクエスト先
+  - hx_post: htmx POST リクエスト先
+  - hx_target: htmx ターゲット要素
+  - hx_swap: htmx スワップ方法
+  - href: リンク先URL（clickableの場合）
+  - class: 追加のCSSクラス
+#}
+
+{% set variant = variant|default('default') %}
+
+{# バリエーション別スタイル #}
+{% if variant == 'hover' %}
+  {% set variant_class = 'hover:shadow-lg hover:-translate-y-1 transition-all duration-200' %}
+{% elif variant == 'clickable' %}
+  {% set variant_class = 'cursor-pointer hover:shadow-lg hover:-translate-y-1 transition-all duration-200' %}
+{% else %}
+  {% set variant_class = '' %}
+{% endif %}
+
+<div
+  class="bg-white rounded-lg shadow-md overflow-hidden {{ variant_class }} {{ class|default('') }}"
+  {% if hx_get %}hx-get="{{ hx_get }}"{% endif %}
+  {% if hx_post %}hx-post="{{ hx_post }}"{% endif %}
+  {% if hx_target %}hx-target="{{ hx_target }}"{% endif %}
+  {% if hx_swap %}hx-swap="{{ hx_swap }}"{% endif %}
+  {% if variant == 'clickable' and href %}onclick="window.location.href='{{ href }}'"{% endif %}
+>
+  {# 画像 #}
+  {% if image_url %}
+    <div class="aspect-video w-full overflow-hidden bg-gray-200">
+      <img src="{{ image_url }}" alt="{{ title }}" class="w-full h-full object-cover">
+    </div>
+  {% endif %}
+
+  {# コンテンツ #}
+  <div class="p-6">
+    {% if title %}
+      <h3 class="text-xl font-semibold text-gray-900 mb-2">{{ title }}</h3>
+    {% endif %}
+
+    {% if description %}
+      <p class="text-gray-600">{{ description }}</p>
+    {% endif %}
+
+    {# カスタムコンテンツ（スロット） #}
+    {{ caller() if caller else '' }}
+  </div>
+
+  {# フッター #}
+  {% if footer_content %}
+    <div class="px-6 py-4 bg-gray-50 border-t border-gray-200">
+      {{ footer_content|safe }}
+    </div>
+  {% endif %}
+</div>

--- a/components/molecules/form-group.html
+++ b/components/molecules/form-group.html
@@ -1,0 +1,37 @@
+{#
+  フォームグループコンポーネント（Label + Input の組み合わせ）
+
+  パラメータ:
+  - label: ラベルテキスト (必須)
+  - name: input要素のname属性 (必須)
+  - id: input要素のid属性 (デフォルト: name)
+  - type: input要素のtype (デフォルト: "text")
+  - placeholder: プレースホルダーテキスト
+  - value: 初期値
+  - required: 必須フラグ
+  - disabled: 無効化フラグ
+  - error: エラーメッセージ
+  - help_text: ヘルプテキスト
+  - hx_get: htmx GET リクエスト先
+  - hx_post: htmx POST リクエスト先
+  - hx_target: htmx ターゲット要素
+  - hx_trigger: htmx トリガーイベント
+  - class: 追加のCSSクラス
+#}
+
+{% set id = id|default(name) %}
+
+<div class="form-group {{ class|default('') }}">
+  {# ラベル #}
+  {% set text = label %}
+  {% set for = id %}
+  {% include 'atoms/label.html' with context %}
+
+  {# 入力フィールド #}
+  {% include 'atoms/input.html' with context %}
+
+  {# ヘルプテキスト #}
+  {% if help_text and not error %}
+    <p class="mt-1 text-sm text-gray-500">{{ help_text }}</p>
+  {% endif %}
+</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,9 +34,12 @@
             <!-- コンポーネントカタログへのリンク -->
             <div class="mt-8 pt-6 border-t border-gray-200">
                 <h2 class="text-xl font-semibold text-gray-800 mb-4">コンポーネントカタログ</h2>
-                <div class="flex gap-4">
+                <div class="flex flex-wrap gap-4">
                     <a href="/atoms" class="inline-flex items-center px-6 py-3 bg-gradient-to-r from-blue-600 to-blue-700 text-white font-medium rounded-lg shadow-md hover:from-blue-700 hover:to-blue-800 transition-all">
                         Atoms →
+                    </a>
+                    <a href="/molecules" class="inline-flex items-center px-6 py-3 bg-gradient-to-r from-purple-600 to-purple-700 text-white font-medium rounded-lg shadow-md hover:from-purple-700 hover:to-purple-800 transition-all">
+                        Molecules →
                     </a>
                 </div>
             </div>

--- a/templates/molecules.html
+++ b/templates/molecules.html
@@ -1,0 +1,166 @@
+{% extends "base.html" %}
+
+{% block title %}Molecules - htmx Design System PoC{% endblock %}
+
+{% block content %}
+<div class="container mx-auto px-4 py-8">
+    <div class="max-w-6xl mx-auto">
+        <h1 class="text-4xl font-bold text-gray-900 mb-2">Molecules コンポーネント</h1>
+        <p class="text-gray-600 mb-8">Atomsを組み合わせたMoleculesコンポーネントのカタログ</p>
+
+        <!-- フォームグループコンポーネント -->
+        <section class="mb-12">
+            <h2 class="text-2xl font-bold text-gray-800 mb-4 pb-2 border-b-2 border-gray-200">フォームグループ</h2>
+
+            <div class="bg-white rounded-lg shadow-md p-6 mb-6">
+                <h3 class="text-lg font-semibold text-gray-700 mb-4">基本的なフォームグループ</h3>
+                <div class="space-y-6 max-w-md">
+                    {% set label = "ユーザー名" %}
+                    {% set name = "username" %}
+                    {% set placeholder = "太郎" %}
+                    {% set required = true %}
+                    {% include 'molecules/form-group.html' with context %}
+
+                    {% set label = "メールアドレス" %}
+                    {% set name = "email" %}
+                    {% set type = "email" %}
+                    {% set placeholder = "taro@example.com" %}
+                    {% set required = true %}
+                    {% set help_text = "有効なメールアドレスを入力してください" %}
+                    {% include 'molecules/form-group.html' with context %}
+
+                    {% set label = "パスワード" %}
+                    {% set name = "password" %}
+                    {% set type = "password" %}
+                    {% set placeholder = "8文字以上" %}
+                    {% set required = true %}
+                    {% set help_text = "パスワードは8文字以上で入力してください" %}
+                    {% include 'molecules/form-group.html' with context %}
+                </div>
+            </div>
+
+            <div class="bg-white rounded-lg shadow-md p-6 mb-6">
+                <h3 class="text-lg font-semibold text-gray-700 mb-4">エラー状態のフォームグループ</h3>
+                <div class="space-y-6 max-w-md">
+                    {% set label = "ユーザー名" %}
+                    {% set name = "username_error" %}
+                    {% set value = "ab" %}
+                    {% set error = "ユーザー名は3文字以上である必要があります" %}
+                    {% set required = true %}
+                    {% set help_text = "" %}
+                    {% include 'molecules/form-group.html' with context %}
+                </div>
+            </div>
+
+            <div class="bg-white rounded-lg shadow-md p-6 mb-6">
+                <h3 class="text-lg font-semibold text-gray-700 mb-4">htmx デモ（リアルタイムフォーム送信）</h3>
+                <div id="form-demo-container">
+                    <form class="space-y-6 max-w-md">
+                        {% set label = "名前" %}
+                        {% set name = "name" %}
+                        {% set placeholder = "山田太郎" %}
+                        {% set required = true %}
+                        {% set error = "" %}
+                        {% set help_text = "" %}
+                        {% include 'molecules/form-group.html' with context %}
+
+                        {% set label = "メッセージ" %}
+                        {% set name = "message" %}
+                        {% set placeholder = "メッセージを入力してください" %}
+                        {% set required = true %}
+                        {% include 'molecules/form-group.html' with context %}
+
+                        <div>
+                            {% set text = "送信" %}
+                            {% set variant = "primary" %}
+                            {% set size = "md" %}
+                            {% set type = "button" %}
+                            {% set hx_post = "/api/demo/submit-form" %}
+                            {% set hx_target = "#form-result" %}
+                            {% set hx_swap = "innerHTML" %}
+                            {% include 'atoms/button.html' with context %}
+                        </div>
+                    </form>
+
+                    <div id="form-result" class="mt-6 p-4 bg-gray-50 rounded-md min-h-[60px]">
+                        <p class="text-gray-500 italic">フォームを送信してください</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- カードコンポーネント -->
+        <section class="mb-12">
+            <h2 class="text-2xl font-bold text-gray-800 mb-4 pb-2 border-b-2 border-gray-200">カード</h2>
+
+            <div class="bg-white rounded-lg shadow-md p-6 mb-6">
+                <h3 class="text-lg font-semibold text-gray-700 mb-4">基本的なカード</h3>
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {% set title = "カードタイトル" %}
+                    {% set description = "これはカードの説明文です。カードは情報をグループ化して表示するのに適しています。" %}
+                    {% set variant = "default" %}
+                    {% include 'molecules/card.html' with context %}
+
+                    {% set title = "画像付きカード" %}
+                    {% set description = "画像を含むカードコンポーネントです。" %}
+                    {% set image_url = "https://via.placeholder.com/400x300/4F46E5/ffffff?text=Sample+Image" %}
+                    {% include 'molecules/card.html' with context %}
+
+                    {% set title = "ホバーエフェクト" %}
+                    {% set description = "マウスオーバーでエフェクトが適用されます。" %}
+                    {% set variant = "hover" %}
+                    {% set image_url = "" %}
+                    {% include 'molecules/card.html' with context %}
+                </div>
+            </div>
+
+            <div class="bg-white rounded-lg shadow-md p-6 mb-6">
+                <h3 class="text-lg font-semibold text-gray-700 mb-4">フッター付きカード</h3>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                    {% set title = "アクション付きカード" %}
+                    {% set description = "フッターにボタンやリンクを配置できます。" %}
+                    {% set variant = "default" %}
+                    {% set text_button = "詳細を見る" %}
+                    {% set footer_content = '<button class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition">詳細を見る</button>' %}
+                    {% include 'molecules/card.html' with context %}
+
+                    {% set title = "複数アクション" %}
+                    {% set description = "複数のアクションボタンを配置することもできます。" %}
+                    {% set footer_content = '<div class="flex gap-3"><button class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition">承認</button><button class="px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition">キャンセル</button></div>' %}
+                    {% include 'molecules/card.html' with context %}
+                </div>
+            </div>
+
+            <div class="bg-white rounded-lg shadow-md p-6 mb-6">
+                <h3 class="text-lg font-semibold text-gray-700 mb-4">htmx デモ（動的コンテンツ読み込み）</h3>
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {% set title = "商品 A" %}
+                    {% set description = "クリックして商品詳細を読み込む" %}
+                    {% set variant = "clickable" %}
+                    {% set hx_get = "/api/demo/product/a" %}
+                    {% set hx_target = "#product-detail" %}
+                    {% set hx_swap = "innerHTML" %}
+                    {% set image_url = "https://via.placeholder.com/400x300/3B82F6/ffffff?text=Product+A" %}
+                    {% include 'molecules/card.html' with context %}
+
+                    {% set title = "商品 B" %}
+                    {% set description = "クリックして商品詳細を読み込む" %}
+                    {% set hx_get = "/api/demo/product/b" %}
+                    {% set image_url = "https://via.placeholder.com/400x300/8B5CF6/ffffff?text=Product+B" %}
+                    {% include 'molecules/card.html' with context %}
+
+                    {% set title = "商品 C" %}
+                    {% set description = "クリックして商品詳細を読み込む" %}
+                    {% set hx_get = "/api/demo/product/c" %}
+                    {% set image_url = "https://via.placeholder.com/400x300/10B981/ffffff?text=Product+C" %}
+                    {% include 'molecules/card.html' with context %}
+                </div>
+
+                <div id="product-detail" class="mt-6 p-6 bg-gray-50 rounded-lg min-h-[120px]">
+                    <p class="text-gray-500 italic">カードをクリックして商品詳細を表示してください</p>
+                </div>
+            </div>
+        </section>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## 概要
Atomsを組み合わせたMoleculesコンポーネントを実装しました。

## 実装内容

### コンポーネント

#### フォームグループコンポーネント（`components/molecules/form-group.html`）
* **構成**: Label + Input を組み合わせた再利用可能なコンポーネント
* **機能**:
  - エラーメッセージ表示
  - ヘルプテキスト表示
  - htmx属性のサポート（リアルタイムバリデーション等）
  - すべてのinput type対応
* **利点**: フォーム要素の統一された表示とバリデーション

#### カードコンポーネント（`components/molecules/card.html`）
* **構成**: 画像、タイトル、説明、フッターを持つカード
* **バリエーション**:
  - `default`: 標準カード
  - `hover`: ホバーエフェクト付き
  - `clickable`: クリック可能なカード
* **機能**:
  - htmx属性のサポート（動的コンテンツ読み込み）
  - カスタムコンテンツ用のcallerスロット
  - フッターエリアでのアクションボタン配置
* **利点**: 情報のグループ化と視覚的な整理

### カタログページ

#### Moleculesカタログページ（`/molecules`）
* 全コンポーネントのデモ表示
* htmxデモ機能:
  - **リアルタイムフォーム送信**: フォームグループを使った送信デモ
  - **動的商品詳細読み込み**: カードクリックで商品情報を動的に表示

### アプリケーション

#### app.pyの更新
* `/molecules`ルートの追加
* htmxデモ用APIエンドポイント:
  - `/api/demo/submit-form`: フォーム送信処理（POST）
  - `/api/demo/product/<id>`: 商品詳細取得（GET）

#### index.htmlの更新
* Moleculesカタログへのナビゲーションリンクを追加

## テスト
* すべてのルートが正常に動作することを確認
* htmx APIエンドポイントが正しく応答することを確認
* コンポーネントが正しくレンダリングされることを確認

## htmx統合パターン
* **フォーム送信**: `hx-post`でフォームデータを送信し、結果を動的に表示
* **動的コンテンツ読み込み**: `hx-get`でサーバーから部分的なHTMLを取得し、指定要素に挿入
* **ターゲット指定**: `hx-target`で更新する要素を指定
* **スワップ方法**: `hx-swap`で挿入方法を制御

## 技術仕様
* **Atomsの再利用**: 既存のAtomsコンポーネントを組み合わせて構築
* **パラメータ化**: Jinja2のパラメータで柔軟なカスタマイズが可能
* **htmx統合**: すべてのコンポーネントでhtmx属性をサポート

## 関連 Issue
Closes #4