### PR TITLE
feat: add organisms catalog demos

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,12 @@ def molecules():
     return render_template('molecules.html')
 
 
+@app.route('/organisms')
+def organisms():
+    """Organismsコンポーネントカタログ"""
+    return render_template('organisms.html')
+
+
 # htmx デモ用APIエンドポイント
 @app.route('/api/demo/message')
 def demo_message():
@@ -127,6 +133,183 @@ def demo_product(product_id):
                 お気に入り
             </button>
         </div>
+    </div>
+    '''
+
+
+@app.route('/api/organisms/modal/<scenario>')
+def organisms_modal_content(scenario):
+    """Organismsモーダルに差し込む部分テンプレート"""
+    modal_content = {
+        'overview': {
+            'badge': 'ハイライト',
+            'title': 'Design System 今週の進捗',
+            'description': 'Atoms/Moleculesレイヤーが完成し、Organismsの実装に着手しました。',
+            'items': [
+                {
+                    'label': 'レイアウトテンプレート',
+                    'value': '4/5 完了',
+                    'note': '基盤となるセクション構造を整備'
+                },
+                {
+                    'label': 'アクセシビリティレビュー',
+                    'value': '進行中',
+                    'note': 'WAI-ARIA属性の棚卸しを実施'
+                },
+                {
+                    'label': 'Storyサンプル',
+                    'value': '8件',
+                    'note': 'ユースケースに紐付いたサンプルを追加'
+                }
+            ]
+        },
+        'release': {
+            'badge': 'Release note',
+            'title': 'v0.3.0 リリース候補',
+            'description': 'Organismsコンポーネントを含むPoC第3弾を今週リリース予定です。',
+            'items': [
+                {
+                    'label': '新機能',
+                    'value': 'モーダル / ナビバー / ステータスパネル',
+                    'note': 'htmx属性付きテンプレートを追加'
+                },
+                {
+                    'label': '改善',
+                    'value': '読み込みインジケーター',
+                    'note': '共通コンポーネント化し、`hx-indicator`で利用可能に'
+                },
+                {
+                    'label': 'デプロイ',
+                    'value': '11/15 予定',
+                    'note': 'PoC用のプレビュー環境に反映'
+                }
+            ]
+        },
+        'feedback': {
+            'badge': 'Feedback',
+            'title': 'ユースケース検証のお願い',
+            'description': 'OrganismsのUI/UXについて、次回レビューまでに確認して欲しい観点をまとめました。',
+            'items': [
+                {
+                    'label': 'レスポンシブ体験',
+                    'value': 'ブレークポイント md / lg',
+                    'note': 'ナビバーのブレークポイント挙動をチェック'
+                },
+                {
+                    'label': '部分更新',
+                    'value': 'hx-swap 動作',
+                    'note': 'モーダル内の差し替えが自然か確認'
+                },
+                {
+                    'label': 'アクセシビリティ',
+                    'value': 'フォーカストラップ',
+                    'note': 'モーダル操作時のキーボード挙動'
+                }
+            ]
+        }
+    }
+
+    content = modal_content.get(scenario, modal_content['overview'])
+
+    items_html = ''.join(
+        f'''
+        <li class="flex items-start gap-4 p-3 rounded-xl border border-gray-100 bg-gray-50">
+            <div>
+                <p class="text-sm font-semibold text-gray-900">{item['label']}</p>
+                <p class="text-xs text-gray-500">{item['note']}</p>
+            </div>
+            <span class="ml-auto text-sm font-semibold text-blue-600">{item['value']}</span>
+        </li>
+        '''
+        for item in content['items']
+    )
+
+    return f'''
+    <div class="space-y-4">
+        <div class="space-y-1">
+            <span class="inline-flex items-center gap-2 rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-700">
+                {content['badge']}
+            </span>
+            <h3 class="text-xl font-bold text-gray-900">{content['title']}</h3>
+            <p class="text-sm text-gray-600">{content['description']}</p>
+        </div>
+        <ul class="space-y-3">
+            {items_html}
+        </ul>
+    </div>
+    '''
+
+
+@app.route('/api/organisms/panel/<panel_id>')
+def organisms_panel(panel_id):
+    """Organismsページのステータスパネル用部分更新"""
+    panel_data = {
+        'growth': {
+            'title': '週次成長サマリー',
+            'badge': 'KPI snapshot',
+            'description': '直近7日間の主要KPIと改善提案です。',
+            'metrics': [
+                {'label': 'Signup conversion', 'value': '+12.4%', 'tone': 'text-emerald-600'},
+                {'label': 'Active teams', 'value': '+8.1%', 'tone': 'text-emerald-600'},
+                {'label': 'Churn', 'value': '-2.3%', 'tone': 'text-emerald-600'}
+            ],
+            'notes': ['プロダクト内ツアーの改善がCVRを押し上げています。', '次のスプリントでリテンション向けモーダル導線をA/Bテスト予定。']
+        },
+        'ops': {
+            'title': '運用タスクリスト',
+            'badge': 'Operations',
+            'description': 'リリース前に完了したいアクションアイテム。',
+            'metrics': [
+                {'label': 'アクセシビリティ監査', 'value': '80% 完了', 'tone': 'text-amber-600'},
+                {'label': 'ドキュメント更新', 'value': '5/8 ページ', 'tone': 'text-gray-700'},
+                {'label': 'テストシナリオ', 'value': '12 ケース', 'tone': 'text-gray-700'}
+            ],
+            'notes': ['残タスク: モーダルのフォーカス管理、ナビバーのキーボード操作。', 'Notionで進捗を同期し、レビューコメントを集約。']
+        },
+        'support': {
+            'title': 'サポートインサイト',
+            'badge': 'Support',
+            'description': '直近の問い合わせ傾向と改善ヒント。',
+            'metrics': [
+                {'label': 'お問い合わせ件数', 'value': '42 (-6)', 'tone': 'text-emerald-600'},
+                {'label': '主要カテゴリ', 'value': 'UIカスタム / API', 'tone': 'text-gray-700'},
+                {'label': '平均初回応答', 'value': '1.8h', 'tone': 'text-blue-600'}
+            ],
+            'notes': ['デザインシステムの使い方ガイドをDocsに追加予定。', '動画チュートリアルの要望が複数寄せられています。']
+        }
+    }
+
+    content = panel_data.get(panel_id, panel_data['growth'])
+    metric_html = ''.join(
+        f'''
+        <li class="flex items-center justify-between rounded-xl bg-white/70 px-4 py-3">
+            <span class="text-sm font-medium text-gray-600">{metric['label']}</span>
+            <span class="text-sm font-semibold {metric['tone']}">{metric['value']}</span>
+        </li>
+        '''
+        for metric in content['metrics']
+    )
+
+    notes_html = ''.join(
+        f'<li class="text-sm text-gray-600 leading-relaxed">{note}</li>'
+        for note in content['notes']
+    )
+
+    return f'''
+    <div class="space-y-5">
+        <div class="space-y-1">
+            <span class="inline-flex items-center gap-2 rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">
+                {content['badge']}
+            </span>
+            <h3 class="text-2xl font-bold text-gray-900">{content['title']}</h3>
+            <p class="text-sm text-gray-600">{content['description']}</p>
+        </div>
+        <ul class="space-y-2">
+            {metric_html}
+        </ul>
+        <ul class="space-y-2 list-disc list-inside">
+            {notes_html}
+        </ul>
     </div>
     '''
 

--- a/components/organisms/loading-indicator.html
+++ b/components/organisms/loading-indicator.html
@@ -1,0 +1,64 @@
+{#
+  ローディングインジケーターコンポーネント
+  htmxのリクエスト中に自動的に表示される
+
+  パラメータ:
+  - id: DOMに付与する任意のID
+  - variant: インジケーターのバリエーション (デフォルト: "spinner")
+    - "spinner": スピナー
+    - "dots": ドット
+    - "bar": プログレスバー
+  - text: 表示テキスト
+  - class: 追加のCSSクラス
+#}
+
+{% set id = id|default('') %}
+{% set variant = variant|default('spinner') %}
+
+<div
+  {% if id %}id="{{ id }}"{% endif %}
+  class="htmx-indicator {{ class|default('') }}"
+>
+  {% if variant == 'spinner' %}
+    <!-- スピナー -->
+    <div class="flex items-center justify-center space-x-2">
+      <svg class="animate-spin h-5 w-5 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+      </svg>
+      {% if text %}
+        <span class="text-sm text-gray-600">{{ text }}</span>
+      {% endif %}
+    </div>
+  {% elif variant == 'dots' %}
+    <!-- ドットアニメーション -->
+    <div class="flex items-center justify-center space-x-2">
+      <div class="w-2 h-2 bg-blue-600 rounded-full animate-bounce" style="animation-delay: 0s;"></div>
+      <div class="w-2 h-2 bg-blue-600 rounded-full animate-bounce" style="animation-delay: 0.1s;"></div>
+      <div class="w-2 h-2 bg-blue-600 rounded-full animate-bounce" style="animation-delay: 0.2s;"></div>
+      {% if text %}
+        <span class="ml-2 text-sm text-gray-600">{{ text }}</span>
+      {% endif %}
+    </div>
+  {% elif variant == 'bar' %}
+    <!-- プログレスバー -->
+    <div class="space-y-2">
+      {% if text %}
+        <span class="text-sm text-gray-600">{{ text }}</span>
+      {% endif %}
+      <div class="w-full bg-gray-200 rounded-full h-2">
+        <div class="bg-blue-600 h-2 rounded-full animate-pulse" style="width: 100%;"></div>
+      </div>
+    </div>
+  {% endif %}
+</div>
+
+<style>
+  .htmx-indicator {
+    display: none;
+  }
+  .htmx-request .htmx-indicator,
+  .htmx-request.htmx-indicator {
+    display: flex;
+  }
+</style>

--- a/components/organisms/modal.html
+++ b/components/organisms/modal.html
@@ -1,0 +1,117 @@
+{#
+  モーダルダイアログコンポーネント
+
+  パラメータ:
+  - id: モーダルのID (必須)
+  - title: モーダルのタイトル
+  - size: モーダルのサイズ (デフォルト: "md")
+    - "sm": 小
+    - "md": 中
+    - "lg": 大
+    - "xl": 特大
+  - show_footer: フッターを表示するか (デフォルト: true)
+  - footer_content: フッターのコンテンツ（HTML）
+  - body_content: モーダルボディに表示するHTMLスニペット
+  - class: 追加のCSSクラス
+#}
+
+{% set size = size|default('md') %}
+{% set show_footer = show_footer|default(true) %}
+{% set body_content = body_content|default('') %}
+
+{# サイズ別スタイル #}
+{% if size == 'sm' %}
+  {% set size_class = 'max-w-sm' %}
+{% elif size == 'md' %}
+  {% set size_class = 'max-w-md' %}
+{% elif size == 'lg' %}
+  {% set size_class = 'max-w-2xl' %}
+{% elif size == 'xl' %}
+  {% set size_class = 'max-w-4xl' %}
+{% else %}
+  {% set size_class = 'max-w-md' %}
+{% endif %}
+
+<div
+  id="{{ id }}"
+  class="fixed inset-0 z-50 overflow-y-auto hidden {{ class|default('') }}"
+  aria-labelledby="{{ id }}-title"
+  role="dialog"
+  aria-modal="true"
+  x-data="{ show: false }"
+  x-show="show"
+  x-on:open-modal.window="if ($event.detail.id === '{{ id }}') show = true"
+  x-on:close-modal.window="if ($event.detail.id === '{{ id }}') show = false"
+  @keydown.escape.window="show = false"
+  style="display: none;"
+>
+  <!-- オーバーレイ -->
+  <div
+    class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+    x-show="show"
+    x-transition:enter="ease-out duration-300"
+    x-transition:enter-start="opacity-0"
+    x-transition:enter-end="opacity-100"
+    x-transition:leave="ease-in duration-200"
+    x-transition:leave-start="opacity-100"
+    x-transition:leave-end="opacity-0"
+    @click="show = false"
+  ></div>
+
+  <!-- モーダルコンテンツ -->
+  <div class="flex items-center justify-center min-h-screen p-4">
+    <div
+      class="relative bg-white rounded-lg shadow-xl w-full {{ size_class }} transform transition-all"
+      x-show="show"
+      x-transition:enter="ease-out duration-300"
+      x-transition:enter-start="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+      x-transition:enter-end="opacity-100 translate-y-0 sm:scale-100"
+      x-transition:leave="ease-in duration-200"
+      x-transition:leave-start="opacity-100 translate-y-0 sm:scale-100"
+      x-transition:leave-end="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
+      @click.stop
+    >
+      <!-- ヘッダー -->
+      <div class="flex items-center justify-between p-6 border-b border-gray-200">
+        {% if title %}
+          <h3 id="{{ id }}-title" class="text-xl font-semibold text-gray-900">
+            {{ title }}
+          </h3>
+        {% endif %}
+        <button
+          @click="show = false"
+          class="text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-lg p-1"
+        >
+          <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+
+      <!-- ボディ -->
+      <div class="p-6 space-y-4">
+        {% if body_content %}
+          {{ body_content|safe }}
+        {% elif caller %}
+          {{ caller() }}
+        {% endif %}
+      </div>
+
+      <!-- フッター -->
+      {% if show_footer %}
+        <div class="flex items-center justify-end gap-3 p-6 border-t border-gray-200">
+          {% if footer_content %}
+            {{ footer_content|safe }}
+          {% else %}
+            <button
+              @click="show = false"
+              class="px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 transition"
+            >
+              閉じる
+            </button>
+          {% endif %}
+        </div>
+      {% endif %}
+    </div>
+  </div>
+</div>

--- a/components/organisms/navbar.html
+++ b/components/organisms/navbar.html
@@ -1,0 +1,106 @@
+{#
+  ナビゲーションバーコンポーネント
+
+  パラメータ:
+  - brand_text: ブランドテキスト (デフォルト: "htmx Design System")
+  - brand_url: ブランドリンク先 (デフォルト: "/")
+  - current_page: 現在のページ (アクティブ状態の表示用)
+  - class: 追加のCSSクラス
+#}
+
+{% set brand_text = brand_text|default('htmx Design System') %}
+{% set brand_url = brand_url|default('/') %}
+
+<nav class="bg-white shadow-md {{ class|default('') }}" x-data="{ mobileMenuOpen: false }">
+  <div class="container mx-auto px-4">
+    <div class="flex items-center justify-between h-16">
+      <!-- ブランド -->
+      <div class="flex-shrink-0">
+        <a href="{{ brand_url }}" class="text-xl font-bold text-gray-900 hover:text-blue-600 transition">
+          {{ brand_text }}
+        </a>
+      </div>
+
+      <!-- デスクトップメニュー -->
+      <div class="hidden md:block">
+        <div class="flex items-center space-x-4">
+          <a
+            href="/"
+            class="px-3 py-2 rounded-md text-sm font-medium transition
+              {% if current_page == 'home' %}bg-blue-100 text-blue-700{% else %}text-gray-700 hover:bg-gray-100{% endif %}"
+          >
+            ホーム
+          </a>
+          <a
+            href="/atoms"
+            class="px-3 py-2 rounded-md text-sm font-medium transition
+              {% if current_page == 'atoms' %}bg-blue-100 text-blue-700{% else %}text-gray-700 hover:bg-gray-100{% endif %}"
+          >
+            Atoms
+          </a>
+          <a
+            href="/molecules"
+            class="px-3 py-2 rounded-md text-sm font-medium transition
+              {% if current_page == 'molecules' %}bg-blue-100 text-blue-700{% else %}text-gray-700 hover:bg-gray-100{% endif %}"
+          >
+            Molecules
+          </a>
+          <a
+            href="/organisms"
+            class="px-3 py-2 rounded-md text-sm font-medium transition
+              {% if current_page == 'organisms' %}bg-blue-100 text-blue-700{% else %}text-gray-700 hover:bg-gray-100{% endif %}"
+          >
+            Organisms
+          </a>
+        </div>
+      </div>
+
+      <!-- モバイルメニューボタン -->
+      <div class="md:hidden">
+        <button
+          @click="mobileMenuOpen = !mobileMenuOpen"
+          class="inline-flex items-center justify-center p-2 rounded-md text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path x-show="!mobileMenuOpen" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+            <path x-show="mobileMenuOpen" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- モバイルメニュー -->
+  <div x-show="mobileMenuOpen" x-transition class="md:hidden border-t border-gray-200">
+    <div class="px-2 pt-2 pb-3 space-y-1">
+      <a
+        href="/"
+        class="block px-3 py-2 rounded-md text-base font-medium transition
+          {% if current_page == 'home' %}bg-blue-100 text-blue-700{% else %}text-gray-700 hover:bg-gray-100{% endif %}"
+      >
+        ホーム
+      </a>
+      <a
+        href="/atoms"
+        class="block px-3 py-2 rounded-md text-base font-medium transition
+          {% if current_page == 'atoms' %}bg-blue-100 text-blue-700{% else %}text-gray-700 hover:bg-gray-100{% endif %}"
+      >
+        Atoms
+      </a>
+      <a
+        href="/molecules"
+        class="block px-3 py-2 rounded-md text-base font-medium transition
+          {% if current_page == 'molecules' %}bg-blue-100 text-blue-700{% else %}text-gray-700 hover:bg-gray-100{% endif %}"
+      >
+        Molecules
+      </a>
+      <a
+        href="/organisms"
+        class="block px-3 py-2 rounded-md text-base font-medium transition
+          {% if current_page == 'organisms' %}bg-blue-100 text-blue-700{% else %}text-gray-700 hover:bg-gray-100{% endif %}"
+      >
+        Organisms
+      </a>
+    </div>
+  </div>
+</nav>

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,6 +41,9 @@
                     <a href="/molecules" class="inline-flex items-center px-6 py-3 bg-gradient-to-r from-purple-600 to-purple-700 text-white font-medium rounded-lg shadow-md hover:from-purple-700 hover:to-purple-800 transition-all">
                         Molecules →
                     </a>
+                    <a href="/organisms" class="inline-flex items-center px-6 py-3 bg-gradient-to-r from-emerald-600 to-emerald-700 text-white font-medium rounded-lg shadow-md hover:from-emerald-700 hover:to-emerald-800 transition-all">
+                        Organisms →
+                    </a>
                 </div>
             </div>
         </div>

--- a/templates/organisms.html
+++ b/templates/organisms.html
@@ -1,0 +1,179 @@
+{% extends "base.html" %}
+
+{% block title %}Organisms - htmx Design System PoC{% endblock %}
+
+{% block content %}
+<div class="bg-gradient-to-b from-slate-50 to-slate-100 min-h-screen pb-16">
+    <div class="container mx-auto px-4 py-8 space-y-12">
+        <header class="text-center space-y-4">
+            <p class="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 uppercase tracking-wide">
+                Organisms Layer
+                <span class="h-1.5 w-1.5 rounded-full bg-blue-400"></span>
+                htmx + Alpine.js Showcase
+            </p>
+            <h1 class="text-4xl font-bold text-gray-900">複合コンポーネント（Organisms）</h1>
+            <p class="max-w-3xl mx-auto text-lg text-gray-600">
+                モーダルやナビゲーションのような複雑なUIパターンを、テンプレートパーツ＋htmxの属性だけで再利用できるようにしたカタログです。
+            </p>
+        </header>
+
+        <!-- Navigation Component Showcase -->
+        <section class="bg-white rounded-2xl shadow-md p-8 space-y-6">
+            <div class="space-y-3">
+                <p class="text-sm font-semibold text-blue-600">Organism 01</p>
+                <div class="flex items-center justify-between flex-wrap gap-4">
+                    <h2 class="text-2xl font-bold text-gray-900">レスポンシブナビゲーション</h2>
+                    <span class="px-3 py-1 rounded-full bg-blue-50 text-blue-700 text-sm font-medium">components/organisms/navbar.html</span>
+                </div>
+                <p class="text-gray-600">
+                    Alpine.jsでモバイルメニューを制御しつつ、現在ページに応じたアクティブスタイルをTailwindで適用しています。
+                    デザインシステムのルートナビゲーションをOrganismとしてカタログ化しました。
+                </p>
+            </div>
+            <div class="border rounded-xl overflow-hidden">
+                {% with brand_text='Design System PoC', current_page='organisms' %}
+                    {% include 'organisms/navbar.html' %}
+                {% endwith %}
+            </div>
+        </section>
+
+        <!-- Modal Component Showcase -->
+        <section class="bg-white rounded-2xl shadow-md p-8 space-y-6" id="modal-demo">
+            <div class="space-y-3">
+                <p class="text-sm font-semibold text-purple-600">Organism 02</p>
+                <div class="flex items-center justify-between flex-wrap gap-4">
+                    <h2 class="text-2xl font-bold text-gray-900">htmx連携モーダル</h2>
+                    <span class="px-3 py-1 rounded-full bg-purple-50 text-purple-700 text-sm font-medium">components/organisms/modal.html</span>
+                </div>
+                <p class="text-gray-600">
+                    `hx-get`, `hx-target`, `hx-swap="innerHTML"` を組み合わせ、モーダル内のコンテンツのみをサーバーから差し替えます。
+                    `hx-indicator` 属性でローディングインジケーターも連携しています。
+                </p>
+            </div>
+
+            <div class="grid gap-8 lg:grid-cols-[1.2fr_1fr]">
+                <div class="space-y-4">
+                    <p class="text-sm text-gray-500">読み込みたいシナリオをクリックすると、サーバー側テンプレートがモーダル内に差し込まれます。</p>
+                    <div class="flex flex-wrap gap-4" x-data="{}">
+                        <button
+                            class="inline-flex items-center gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:border-blue-500 hover:text-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            hx-get="/api/organisms/modal/overview"
+                            hx-target="#demo-modal-content"
+                            hx-swap="innerHTML"
+                            hx-indicator="#modal-loading-indicator"
+                            @click="$dispatch('open-modal', { id: 'demo-modal' })"
+                        >
+                            プロジェクト概要
+                        </button>
+                        <button
+                            class="inline-flex items-center gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:border-blue-500 hover:text-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            hx-get="/api/organisms/modal/release"
+                            hx-target="#demo-modal-content"
+                            hx-swap="innerHTML"
+                            hx-indicator="#modal-loading-indicator"
+                            @click="$dispatch('open-modal', { id: 'demo-modal' })"
+                        >
+                            リリースノート
+                        </button>
+                        <button
+                            class="inline-flex items-center gap-2 rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:border-blue-500 hover:text-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            hx-get="/api/organisms/modal/feedback"
+                            hx-target="#demo-modal-content"
+                            hx-swap="innerHTML"
+                            hx-indicator="#modal-loading-indicator"
+                            @click="$dispatch('open-modal', { id: 'demo-modal' })"
+                        >
+                            フィードバック収集
+                        </button>
+                    </div>
+                </div>
+
+                <div class="bg-gradient-to-br from-purple-50 to-blue-50 rounded-xl p-6 space-y-3">
+                    <h3 class="text-sm font-semibold text-purple-700 uppercase tracking-wide">htmx フロー</h3>
+                    <ol class="space-y-3 text-sm text-gray-600">
+                        <li><span class="font-semibold text-gray-800">1.</span> ボタンの `hx-get` がサーバーへリクエスト</li>
+                        <li><span class="font-semibold text-gray-800">2.</span> レスポンスHTMLを `hx-target="#demo-modal-content"` へ挿入</li>
+                        <li><span class="font-semibold text-gray-800">3.</span> `hx-swap="innerHTML"` でボディのみ差し替え、モーダルは開いたまま</li>
+                        <li><span class="font-semibold text-gray-800">4.</span> リクエスト中は `hx-indicator` でローディング表示</li>
+                    </ol>
+                </div>
+            </div>
+
+            {% set modal_body %}
+                <div id="demo-modal-content" class="space-y-3 text-gray-600">
+                    <p class="text-gray-500">アクションを選択するとここに詳細が表示されます。</p>
+                </div>
+                {% with id='modal-loading-indicator', variant='spinner', text='サーバーからコンテンツを取得しています…', class='justify-center text-sm text-gray-600 gap-3 mt-2' %}
+                    {% include 'organisms/loading-indicator.html' %}
+                {% endwith %}
+            {% endset %}
+            {% with id='demo-modal', title='サーバー連携モーダル', size='lg', body_content=modal_body %}
+                {% include 'organisms/modal.html' %}
+            {% endwith %}
+        </section>
+
+        <!-- Partial Updates & Loading Indicator Showcase -->
+        <section class="bg-white rounded-2xl shadow-md p-8 space-y-6" id="partial-updates">
+            <div class="space-y-3">
+                <p class="text-sm font-semibold text-emerald-600">Organism 03</p>
+                <div class="flex items-center justify-between flex-wrap gap-4">
+                    <h2 class="text-2xl font-bold text-gray-900">部分更新パネル + インジケーター</h2>
+                    <span class="px-3 py-1 rounded-full bg-emerald-50 text-emerald-700 text-sm font-medium">components/organisms/loading-indicator.html</span>
+                </div>
+                <p class="text-gray-600">
+                    `hx-target="#status-panel"` と `hx-swap="innerHTML"` で右側パネルのみ更新。
+                    `hx-indicator="#panel-indicator"` がローディング状態を視覚化します。
+                </p>
+            </div>
+
+            <div class="grid gap-6 lg:grid-cols-[320px_1fr]">
+                <div class="space-y-3">
+                    <p class="text-xs uppercase text-gray-500 tracking-wide">サーバーから読み込むテーマ</p>
+                    <div class="flex flex-col gap-3">
+                        <button
+                            class="text-left rounded-xl border border-gray-200 px-4 py-3 hover:border-emerald-400 hover:bg-emerald-50"
+                            hx-get="/api/organisms/panel/growth"
+                            hx-target="#status-panel"
+                            hx-swap="innerHTML"
+                            hx-indicator="#panel-indicator"
+                        >
+                            <span class="block text-sm font-semibold text-gray-900">成長指標レポート</span>
+                            <span class="block text-xs text-gray-500">プロダクトKPIのサマリー</span>
+                        </button>
+                        <button
+                            class="text-left rounded-xl border border-gray-200 px-4 py-3 hover:border-emerald-400 hover:bg-emerald-50"
+                            hx-get="/api/organisms/panel/ops"
+                            hx-target="#status-panel"
+                            hx-swap="innerHTML"
+                            hx-indicator="#panel-indicator"
+                        >
+                            <span class="block text-sm font-semibold text-gray-900">運用タスク</span>
+                            <span class="block text-xs text-gray-500">チームアクションアイテム</span>
+                        </button>
+                        <button
+                            class="text-left rounded-xl border border-gray-200 px-4 py-3 hover:border-emerald-400 hover:bg-emerald-50"
+                            hx-get="/api/organisms/panel/support"
+                            hx-target="#status-panel"
+                            hx-swap="innerHTML"
+                            hx-indicator="#panel-indicator"
+                        >
+                            <span class="block text-sm font-semibold text-gray-900">サポートインサイト</span>
+                            <span class="block text-xs text-gray-500">問い合わせトレンド</span>
+                        </button>
+                    </div>
+                </div>
+
+                <div class="relative rounded-2xl border border-dashed border-emerald-200 bg-emerald-50/40 p-6">
+                    <div id="status-panel" class="space-y-4 text-gray-700">
+                        <h3 class="text-lg font-semibold text-gray-900">右のリクエスト結果領域</h3>
+                        <p class="text-gray-600 text-sm">左のトピックをクリックすると、この領域だけが `hx-swap` で差し替わります。</p>
+                    </div>
+                    {% with id='panel-indicator', variant='dots', text='更新中…', class='absolute bottom-6 right-6 bg-white/80 px-3 py-1.5 rounded-full shadow text-gray-600 items-center gap-2' %}
+                        {% include 'organisms/loading-indicator.html' %}
+                    {% endwith %}
+                </div>
+            </div>
+        </section>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary\n- introduce Organisms catalog page with navigation, modal, and partial update showcases\n- add reusable modal/loading indicator components plus supporting API endpoints\n- link the new page from the home catalog\n\n## Testing\n- python3 -m py_compile app.py\n\nCloses #5