### PR TITLE
feat: add component catalog page

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,77 @@ app = Flask(__name__)
 app.jinja_loader.searchpath.append('components')
 
 
+CATALOG_COMPONENTS = [
+    {
+        'slug': 'atoms-button',
+        'title': 'Button',
+        'category': 'Atoms',
+        'summary': 'Tailwindとhtmx向けの汎用ボタン',
+        'template': 'catalog/components/atoms-button.html'
+    },
+    {
+        'slug': 'atoms-input',
+        'title': 'Input',
+        'category': 'Atoms',
+        'summary': 'バリデーションやhtmxイベント対応の入力欄',
+        'template': 'catalog/components/atoms-input.html'
+    },
+    {
+        'slug': 'atoms-label',
+        'title': 'Label',
+        'category': 'Atoms',
+        'summary': '必須マークにも対応したテキストラベル',
+        'template': 'catalog/components/atoms-label.html'
+    },
+    {
+        'slug': 'atoms-text',
+        'title': 'Text',
+        'category': 'Atoms',
+        'summary': 'バリエーション豊富なテキストスタイル',
+        'template': 'catalog/components/atoms-text.html'
+    },
+    {
+        'slug': 'molecules-form-group',
+        'title': 'Form Group',
+        'category': 'Molecules',
+        'summary': 'ラベル＋入力＋ヘルプ/エラーをまとめたフォームブロック',
+        'template': 'catalog/components/molecules-form-group.html'
+    },
+    {
+        'slug': 'molecules-card',
+        'title': 'Card',
+        'category': 'Molecules',
+        'summary': '画像やアクションを含む情報カード',
+        'template': 'catalog/components/molecules-card.html'
+    },
+    {
+        'slug': 'organisms-navbar',
+        'title': 'Navbar',
+        'category': 'Organisms',
+        'summary': 'レスポンシブナビゲーションバー',
+        'template': 'catalog/components/organisms-navbar.html'
+    },
+    {
+        'slug': 'organisms-modal',
+        'title': 'Modal',
+        'category': 'Organisms',
+        'summary': 'htmxでコンテンツを差し替えるモーダル',
+        'template': 'catalog/components/organisms-modal.html'
+    },
+    {
+        'slug': 'organisms-loading-indicator',
+        'title': 'Loading Indicator',
+        'category': 'Organisms',
+        'summary': 'hx-indicator向けローディング表示',
+        'template': 'catalog/components/organisms-loading-indicator.html'
+    }
+]
+
+CATALOG_TEMPLATE_MAP = {
+    component['slug']: component['template'] for component in CATALOG_COMPONENTS
+}
+
+
 @app.route('/')
 def index():
     """メインページ"""
@@ -22,6 +93,13 @@ def atoms():
 def molecules():
     """Moleculesコンポーネントカタログ"""
     return render_template('molecules.html')
+
+
+@app.route('/catalog')
+def catalog():
+    """コンポーネントカタログのトップページ"""
+    default_slug = CATALOG_COMPONENTS[0]['slug'] if CATALOG_COMPONENTS else ''
+    return render_template('catalog.html', components=CATALOG_COMPONENTS, default_component=default_slug)
 
 
 @app.route('/organisms')
@@ -135,6 +213,17 @@ def demo_product(product_id):
         </div>
     </div>
     '''
+
+
+@app.route('/api/catalog/<component_slug>')
+def catalog_component_detail(component_slug):
+    """特定コンポーネントのデモ/スニペットを返す"""
+    template = CATALOG_TEMPLATE_MAP.get(component_slug)
+    if not template:
+        return '<div class="p-6 text-red-600">コンポーネントが見つかりません</div>', 404
+
+    component_meta = next((c for c in CATALOG_COMPONENTS if c['slug'] == component_slug), None)
+    return render_template(template, component=component_meta)
 
 
 @app.route('/api/organisms/modal/<scenario>')

--- a/components/organisms/navbar.html
+++ b/components/organisms/navbar.html
@@ -52,6 +52,13 @@
           >
             Organisms
           </a>
+          <a
+            href="/catalog"
+            class="px-3 py-2 rounded-md text-sm font-medium transition
+              {% if current_page == 'catalog' %}bg-blue-100 text-blue-700{% else %}text-gray-700 hover:bg-gray-100{% endif %}"
+          >
+            Catalog
+          </a>
         </div>
       </div>
 
@@ -100,6 +107,13 @@
           {% if current_page == 'organisms' %}bg-blue-100 text-blue-700{% else %}text-gray-700 hover:bg-gray-100{% endif %}"
       >
         Organisms
+      </a>
+      <a
+        href="/catalog"
+        class="block px-3 py-2 rounded-md text-base font-medium transition
+          {% if current_page == 'catalog' %}bg-blue-100 text-blue-700{% else %}text-gray-700 hover:bg-gray-100{% endif %}"
+      >
+        Catalog
       </a>
     </div>
   </div>

--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -1,0 +1,77 @@
+{% extends "base.html" %}
+
+{% block title %}Component Catalog - htmx Design System PoC{% endblock %}
+
+{% block content %}
+<div class="bg-slate-950/5 py-10 min-h-screen">
+    <div class="container mx-auto px-4 space-y-10">
+        <header class="max-w-4xl space-y-4">
+            <p class="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 uppercase tracking-widest">
+                Component Catalog
+                <span class="h-1.5 w-1.5 rounded-full bg-blue-400"></span>
+                Live Playground
+            </p>
+            <h1 class="text-4xl font-extrabold text-gray-900">コンポーネントカタログ</h1>
+            <p class="text-lg text-gray-600">
+                Atoms / Molecules / Organisms の全コンポーネントを1つの画面で試し、コードスニペットを確認できます。
+                左のリストから対象を選ぶと、右にデモとバリエーションが表示されます。
+            </p>
+        </header>
+
+        <div class="grid gap-8 lg:grid-cols-[320px_1fr]">
+            <aside
+                class="bg-white rounded-2xl shadow-sm border border-slate-100 p-5"
+                x-data="{ active: '{{ default_component }}' }"
+            >
+                <div class="space-y-6">
+                    {% for category, items in components|groupby('category') %}
+                        <div class="space-y-2">
+                            <p class="text-xs uppercase tracking-wide text-gray-400">{{ category }}</p>
+                            <div class="space-y-2">
+                                {% for item in items %}
+                                    <button
+                                        class="w-full text-left px-4 py-3 rounded-xl border transition focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                        :class="active === '{{ item.slug }}' ? 'border-blue-500 bg-blue-50 text-blue-700' : 'border-transparent text-gray-600 hover:border-gray-200 hover:bg-gray-50'"
+                                        hx-get="/api/catalog/{{ item.slug }}"
+                                        hx-target="#catalog-detail"
+                                        hx-swap="innerHTML"
+                                        hx-indicator="#catalog-detail-indicator"
+                                        @click="active = '{{ item.slug }}'"
+                                    >
+                                        <p class="text-sm font-semibold">{{ item.title }}</p>
+                                        <p class="text-xs text-gray-500">{{ item.summary }}</p>
+                                    </button>
+                                {% endfor %}
+                            </div>
+                        </div>
+                    {% endfor %}
+                </div>
+            </aside>
+
+            <div class="relative">
+                <div
+                    id="catalog-detail"
+                    class="bg-white rounded-3xl shadow-lg border border-slate-100 p-8 min-h-[520px]"
+                    hx-get="/api/catalog/{{ default_component }}"
+                    hx-trigger="load"
+                    hx-target="#catalog-detail"
+                    hx-swap="innerHTML"
+                    hx-indicator="#catalog-detail-indicator"
+                >
+                    <div class="flex items-center gap-3 text-gray-500">
+                        <svg class="w-5 h-5 animate-spin text-blue-500" viewBox="0 0 24 24">
+                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" fill="none" />
+                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                        </svg>
+                        <p>コンポーネントを読み込み中...</p>
+                    </div>
+                </div>
+
+                {% with id='catalog-detail-indicator', variant='dots', text='Loading component…', class='absolute top-6 right-6 bg-white/90 px-4 py-1.5 rounded-full shadow items-center gap-2 text-gray-600' %}
+                    {% include 'organisms/loading-indicator.html' %}
+                {% endwith %}
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/catalog/components/atoms-button.html
+++ b/templates/catalog/components/atoms-button.html
@@ -1,0 +1,64 @@
+{% set snippet %}
+{% raw %}
+{% with text='Primary action', variant='primary' %}
+    {% include 'atoms/button.html' %}
+{% endwith %}
+{% with text='Secondary', variant='secondary' %}
+    {% include 'atoms/button.html' %}
+{% endwith %}
+{% with text='Danger zone', variant='danger' %}
+    {% include 'atoms/button.html' %}
+{% endwith %}
+{% endraw %}
+{% endset %}
+
+<div class="space-y-8" x-data="{ showCode: false }">
+    <header class="space-y-2">
+        <p class="text-xs uppercase tracking-wide text-blue-600">{{ component.category }} / {{ component.title }}</p>
+        <h2 class="text-3xl font-bold text-gray-900">ボタンのスタイルバリエーション</h2>
+        <p class="text-gray-600">htmx属性と組み合わせ可能なTailwindベースのボタンコンポーネントです。</p>
+    </header>
+
+    <div class="grid gap-6 lg:grid-cols-2">
+        <div class="space-y-4">
+            <p class="text-sm font-semibold text-gray-500">プレビュー</p>
+            <div class="flex flex-wrap gap-4">
+                {% with text='Primary action', variant='primary' %}
+                    {% include 'atoms/button.html' %}
+                {% endwith %}
+                {% with text='Secondary', variant='secondary' %}
+                    {% include 'atoms/button.html' %}
+                {% endwith %}
+                {% with text='Danger zone', variant='danger' %}
+                    {% include 'atoms/button.html' %}
+                {% endwith %}
+                {% with text='Outline', variant='outline' %}
+                    {% include 'atoms/button.html' %}
+                {% endwith %}
+            </div>
+            <p class="text-xs text-gray-400">サイズやhx-*属性は`with`ブロックで自由に上書きできます。</p>
+        </div>
+        <div class="bg-slate-50 rounded-2xl p-5 space-y-3">
+            <p class="font-semibold text-gray-800">バリエーション一覧</p>
+            <ul class="space-y-2 text-sm text-gray-600">
+                <li><span class="font-semibold text-gray-900">Primary:</span> 主要アクション用。青のフルフィルボタン。</li>
+                <li><span class="font-semibold text-gray-900">Secondary:</span> サブアクション向けダークグレー。</li>
+                <li><span class="font-semibold text-gray-900">Danger:</span> 破壊的操作の注意喚起。</li>
+                <li><span class="font-semibold text-gray-900">Outline:</span> 目立たせすぎない補助アクション。</li>
+            </ul>
+        </div>
+    </div>
+
+    <div class="border border-slate-200 rounded-2xl overflow-hidden">
+        <button
+            class="w-full flex items-center justify-between px-5 py-3 text-sm font-semibold text-gray-700"
+            @click="showCode = !showCode"
+        >
+            <span>コードスニペット</span>
+            <span x-text="showCode ? '−' : '+'"></span>
+        </button>
+        <div x-show="showCode" x-transition class="bg-slate-900 text-slate-50 text-sm">
+            <pre class="overflow-x-auto p-5"><code>{{ snippet|trim|e }}</code></pre>
+        </div>
+    </div>
+</div>

--- a/templates/catalog/components/atoms-input.html
+++ b/templates/catalog/components/atoms-input.html
@@ -1,0 +1,73 @@
+{% set snippet %}
+{% raw %}
+{% with name='username', placeholder='ユーザー名', required=true %}
+    {% include 'atoms/input.html' %}
+{% endwith %}
+{% with name='email', type='email', placeholder='you@example.com' %}
+    {% include 'atoms/input.html' %}
+{% endwith %}
+<div class="space-y-2" hx-target="#input-feedback">
+    {% with name='username', hx_post='/api/validate/username', hx_target='#input-feedback', hx_trigger='blur', placeholder='htmxでバリデーション' %}
+        {% include 'atoms/input.html' %}
+    {% endwith %}
+    <div id="input-feedback" class="text-sm text-gray-500"></div>
+</div>
+{% endraw %}
+{% endset %}
+
+<div class="space-y-8" x-data="{ showCode: false }">
+    <header class="space-y-2">
+        <p class="text-xs uppercase tracking-wide text-blue-600">{{ component.category }} / {{ component.title }}</p>
+        <h2 class="text-3xl font-bold text-gray-900">フォーム入力の状態管理</h2>
+        <p class="text-gray-600">エラー表示やhtmxによる非同期バリデーションを組み込みやすいAtomです。</p>
+    </header>
+
+    <div class="grid gap-6 lg:grid-cols-2">
+        <div class="space-y-4">
+            <p class="text-sm font-semibold text-gray-500">プレビュー</p>
+            <div class="space-y-4">
+                <div>
+                    <p class="text-xs text-gray-500 mb-1">デフォルト</p>
+                    {% with name='username', placeholder='山田太郎', required=true %}
+                        {% include 'atoms/input.html' %}
+                    {% endwith %}
+                </div>
+                <div>
+                    <p class="text-xs text-gray-500 mb-1">エラー状態</p>
+                    {% with name='username', placeholder='ab', error='3文字以上で入力してください' %}
+                        {% include 'atoms/input.html' %}
+                    {% endwith %}
+                </div>
+                <div>
+                    <p class="text-xs text-gray-500 mb-1">htmxバリデーション</p>
+                    <div hx-target="#input-validation-feedback" hx-indicator="#input-validation-indicator">
+                        {% with name='username', placeholder='非同期でチェック', hx_post='/api/validate/username', hx_target='#input-validation-feedback', hx_trigger='keyup changed delay:500ms' %}
+                            {% include 'atoms/input.html' %}
+                        {% endwith %}
+                        <div class="text-sm text-gray-500 min-h-[24px] flex items-center" id="input-validation-feedback"></div>
+                        <div id="input-validation-indicator" class="text-xs text-blue-600 htmx-indicator">チェック中...</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="bg-slate-50 rounded-2xl p-5 space-y-3">
+            <p class="font-semibold text-gray-800">バリエーション一覧</p>
+            <ul class="space-y-2 text-sm text-gray-600">
+                <li><span class="font-semibold text-gray-900">type:</span> text/email/password など任意のタイプに対応。</li>
+                <li><span class="font-semibold text-gray-900">state:</span> errorが指定されると赤枠＋テキストを表示。</li>
+                <li><span class="font-semibold text-gray-900">htmx:</span> hx-get/hx-post/hx-trigger/hx-targetを直接指定可能。</li>
+                <li><span class="font-semibold text-gray-900">disabled:</span> 利用不可状態でもTailwindのトークンで整形。</li>
+            </ul>
+        </div>
+    </div>
+
+    <div class="border border-slate-200 rounded-2xl overflow-hidden">
+        <button class="w-full flex items-center justify-between px-5 py-3 text-sm font-semibold text-gray-700" @click="showCode = !showCode">
+            <span>コードスニペット</span>
+            <span x-text="showCode ? '−' : '+'"></span>
+        </button>
+        <div x-show="showCode" x-transition class="bg-slate-900 text-slate-50 text-sm">
+            <pre class="overflow-x-auto p-5"><code>{{ snippet|trim|e }}</code></pre>
+        </div>
+    </div>
+</div>

--- a/templates/catalog/components/atoms-label.html
+++ b/templates/catalog/components/atoms-label.html
@@ -1,0 +1,60 @@
+{% set snippet %}
+{% raw %}
+{% with text='ユーザー名', required=true, for='username' %}
+    {% include 'atoms/label.html' %}
+{% endwith %}
+{% with text='任意項目', class='text-gray-500' %}
+    {% include 'atoms/label.html' %}
+{% endwith %}
+{% endraw %}
+{% endset %}
+
+<div class="space-y-8" x-data="{ showCode: false }">
+    <header class="space-y-2">
+        <p class="text-xs uppercase tracking-wide text-blue-600">{{ component.category }} / {{ component.title }}</p>
+        <h2 class="text-3xl font-bold text-gray-900">アクセシブルなラベル</h2>
+        <p class="text-gray-600">`for`属性や必須マークを簡潔に制御し、フォーム要素と組み合わせて利用できます。</p>
+    </header>
+
+    <div class="grid gap-6 lg:grid-cols-2">
+        <div class="space-y-4">
+            <p class="text-sm font-semibold text-gray-500">プレビュー</p>
+            <div class="space-y-4">
+                <div>
+                    {% with text='ユーザー名', required=true, for='catalog-username' %}
+                        {% include 'atoms/label.html' %}
+                    {% endwith %}
+                    {% with name='catalog-username', placeholder='山田太郎' %}
+                        {% include 'atoms/input.html' %}
+                    {% endwith %}
+                </div>
+                <div>
+                    {% with text='任意項目', class='text-gray-500' %}
+                        {% include 'atoms/label.html' %}
+                    {% endwith %}
+                    {% with name='catalog-optional', placeholder='オプション' %}
+                        {% include 'atoms/input.html' %}
+                    {% endwith %}
+                </div>
+            </div>
+        </div>
+        <div class="bg-slate-50 rounded-2xl p-5 space-y-3">
+            <p class="font-semibold text-gray-800">バリエーション一覧</p>
+            <ul class="space-y-2 text-sm text-gray-600">
+                <li><span class="font-semibold text-gray-900">required:</span> trueで`*`を表示。</li>
+                <li><span class="font-semibold text-gray-900">for:</span> フォーム要素のidと紐付け、スクリーンリーダー対応。</li>
+                <li><span class="font-semibold text-gray-900">class:</span> Tailwindクラスを拡張してラベルの表現を調整。</li>
+            </ul>
+        </div>
+    </div>
+
+    <div class="border border-slate-200 rounded-2xl overflow-hidden">
+        <button class="w-full flex items-center justify-between px-5 py-3 text-sm font-semibold text-gray-700" @click="showCode = !showCode">
+            <span>コードスニペット</span>
+            <span x-text="showCode ? '−' : '+'"></span>
+        </button>
+        <div x-show="showCode" x-transition class="bg-slate-900 text-slate-50 text-sm">
+            <pre class="overflow-x-auto p-5"><code>{{ snippet|trim|e }}</code></pre>
+        </div>
+    </div>
+</div>

--- a/templates/catalog/components/atoms-text.html
+++ b/templates/catalog/components/atoms-text.html
@@ -1,0 +1,69 @@
+{% set snippet %}
+{% raw %}
+{% with content='headingスタイル', variant='heading' %}
+    {% include 'atoms/text.html' %}
+{% endwith %}
+{% with content='subheadingスタイル', variant='subheading' %}
+    {% include 'atoms/text.html' %}
+{% endwith %}
+{% with content='本文テキスト', variant='body' %}
+    {% include 'atoms/text.html' %}
+{% endwith %}
+{% with content='補足説明', variant='caption' %}
+    {% include 'atoms/text.html' %}
+{% endwith %}
+{% endraw %}
+{% endset %}
+
+<div class="space-y-8" x-data="{ showCode: false }">
+    <header class="space-y-2">
+        <p class="text-xs uppercase tracking-wide text-blue-600">{{ component.category }} / {{ component.title }}</p>
+        <h2 class="text-3xl font-bold text-gray-900">テキストスケール</h2>
+        <p class="text-gray-600">ヘッダーからキャプション、状態メッセージまで一貫したタイポグラフィを提供します。</p>
+    </header>
+
+    <div class="grid gap-6 lg:grid-cols-2">
+        <div class="space-y-4">
+            <p class="text-sm font-semibold text-gray-500">プレビュー</p>
+            <div class="space-y-3">
+                {% with content='Heading / L', variant='heading' %}
+                    {% include 'atoms/text.html' %}
+                {% endwith %}
+                {% with content='Subheading', variant='subheading' %}
+                    {% include 'atoms/text.html' %}
+                {% endwith %}
+                {% with content='Body text for paragraphs', variant='body' %}
+                    {% include 'atoms/text.html' %}
+                {% endwith %}
+                {% with content='Caption text', variant='caption' %}
+                    {% include 'atoms/text.html' %}
+                {% endwith %}
+                {% with content='エラーメッセージ', variant='error' %}
+                    {% include 'atoms/text.html' %}
+                {% endwith %}
+                {% with content='成功メッセージ', variant='success' %}
+                    {% include 'atoms/text.html' %}
+                {% endwith %}
+            </div>
+        </div>
+        <div class="bg-slate-50 rounded-2xl p-5 space-y-3">
+            <p class="font-semibold text-gray-800">バリエーション一覧</p>
+            <ul class="space-y-2 text-sm text-gray-600">
+                <li><span class="font-semibold text-gray-900">heading / subheading:</span> 見出しやセクションタイトル用。</li>
+                <li><span class="font-semibold text-gray-900">body:</span> 標準の段落・説明テキスト。</li>
+                <li><span class="font-semibold text-gray-900">caption:</span> 補足情報やツールチップに適した小さい文字。</li>
+                <li><span class="font-semibold text-gray-900">error / success:</span> 状態メッセージのカラーリングを統一。</li>
+            </ul>
+        </div>
+    </div>
+
+    <div class="border border-slate-200 rounded-2xl overflow-hidden">
+        <button class="w-full flex items-center justify-between px-5 py-3 text-sm font-semibold text-gray-700" @click="showCode = !showCode">
+            <span>コードスニペット</span>
+            <span x-text="showCode ? '−' : '+'"></span>
+        </button>
+        <div x-show="showCode" x-transition class="bg-slate-900 text-slate-50 text-sm">
+            <pre class="overflow-x-auto p-5"><code>{{ snippet|trim|e }}</code></pre>
+        </div>
+    </div>
+</div>

--- a/templates/catalog/components/molecules-card.html
+++ b/templates/catalog/components/molecules-card.html
@@ -1,0 +1,71 @@
+{% set snippet %}
+{% raw %}
+<div class="grid gap-6 md:grid-cols-2">
+    {% with title='基本カード', description='テキストのみのシンプルなカード' %}
+        {% include 'molecules/card.html' %}
+    {% endwith %}
+    {% with title='画像付き', description='ビジュアルを含むカード', image_url='https://via.placeholder.com/400x240/4F46E5/ffffff?text=Card' %}
+        {% include 'molecules/card.html' %}
+    {% endwith %}
+</div>
+{% with title='商品詳細', description='クリックして詳細を読み込み', variant='clickable', hx_get='/api/demo/product/a', hx_target='#card-preview-detail', hx_swap='innerHTML' %}
+    {% include 'molecules/card.html' %}
+{% endwith %}
+<div id="card-preview-detail" class="mt-3 text-sm text-gray-500"></div>
+{% endraw %}
+{% endset %}
+
+<div class="space-y-8" x-data="{ showCode: false }">
+    <header class="space-y-2">
+        <p class="text-xs uppercase tracking-wide text-purple-600">{{ component.category }} / {{ component.title }}</p>
+        <h2 class="text-3xl font-bold text-gray-900">カードデザイン</h2>
+        <p class="text-gray-600">情報のまとまりをボックス化し、必要に応じて画像・アクションやhtmx連携を追加できます。</p>
+    </header>
+
+    <div class="space-y-6">
+        <div>
+            <p class="text-sm font-semibold text-gray-500 mb-4">プレビュー</p>
+            <div class="grid gap-6 lg:grid-cols-3">
+                {% with title='基本カード', description='テキストのみのシンプルなカード' %}
+                    {% include 'molecules/card.html' %}
+                {% endwith %}
+                {% with title='画像付き', description='ビジュアルを含むカード', image_url='https://via.placeholder.com/400x240/4F46E5/ffffff?text=Card' %}
+                    {% include 'molecules/card.html' %}
+                {% endwith %}
+                {% with title='アクション付き', description='フッターにアクションを配置', footer_content='<button class="px-4 py-2 bg-blue-600 text-white rounded-lg">詳細を見る</button>' %}
+                    {% include 'molecules/card.html' %}
+                {% endwith %}
+            </div>
+        </div>
+        <div class="grid gap-6 lg:grid-cols-2">
+            <div class="space-y-3">
+                <p class="text-sm font-semibold text-gray-500">htmx連携サンプル</p>
+                {% with title='商品カード', description='クリックで右側に詳細をロード', variant='clickable', hx_get='/api/demo/product/b', hx_target='#card-detail-panel', hx_swap='innerHTML', image_url='https://via.placeholder.com/400x240/3B82F6/ffffff?text=htmx' %}
+                    {% include 'molecules/card.html' %}
+                {% endwith %}
+            </div>
+            <div id="card-detail-panel" class="min-h-[160px] rounded-2xl border border-dashed border-purple-200 bg-purple-50/60 p-5 text-gray-600">
+                <p class="text-sm">カードをクリックするとサーバーから詳細を取得します。</p>
+            </div>
+        </div>
+        <div class="bg-purple-50 rounded-2xl p-5 space-y-3">
+            <p class="font-semibold text-gray-800">バリエーション一覧</p>
+            <ul class="space-y-2 text-sm text-gray-600">
+                <li><span class="font-semibold text-gray-900">default:</span> テキスト主体の標準カード。</li>
+                <li><span class="font-semibold text-gray-900">hover:</span> マウスオーバー時の浮き上がり演出を付与。</li>
+                <li><span class="font-semibold text-gray-900">clickable:</span> クリックアクション + hx-get をセットして詳細表示に活用。</li>
+                <li><span class="font-semibold text-gray-900">footer_content:</span> HTMLを受け取りアクションボタンやメタ情報を配置。</li>
+            </ul>
+        </div>
+    </div>
+
+    <div class="border border-slate-200 rounded-2xl overflow-hidden">
+        <button class="w-full flex items-center justify-between px-5 py-3 text-sm font-semibold text-gray-700" @click="showCode = !showCode">
+            <span>コードスニペット</span>
+            <span x-text="showCode ? '−' : '+'"></span>
+        </button>
+        <div x-show="showCode" x-transition class="bg-slate-900 text-slate-50 text-sm">
+            <pre class="overflow-x-auto p-5"><code>{{ snippet|trim|e }}</code></pre>
+        </div>
+    </div>
+</div>

--- a/templates/catalog/components/molecules-form-group.html
+++ b/templates/catalog/components/molecules-form-group.html
@@ -1,0 +1,56 @@
+{% set snippet %}
+{% raw %}
+{% with label='ユーザー名', name='username', placeholder='山田太郎', required=true %}
+    {% include 'molecules/form-group.html' %}
+{% endwith %}
+{% with label='メールアドレス', name='email', type='email', placeholder='you@example.com', help_text='通知を受け取るメールアドレス' %}
+    {% include 'molecules/form-group.html' %}
+{% endwith %}
+{% with label='ユーザーID', name='user_id', value='ab', error='3文字以上で入力してください' %}
+    {% include 'molecules/form-group.html' %}
+{% endwith %}
+{% endraw %}
+{% endset %}
+
+<div class="space-y-8" x-data="{ showCode: false }">
+    <header class="space-y-2">
+        <p class="text-xs uppercase tracking-wide text-purple-600">{{ component.category }} / {{ component.title }}</p>
+        <h2 class="text-3xl font-bold text-gray-900">フォームグループ</h2>
+        <p class="text-gray-600">ラベル、入力、補足文/エラーをまとめて扱えるMolecule。Atomsに比べた状態管理が容易です。</p>
+    </header>
+
+    <div class="grid gap-6 lg:grid-cols-2">
+        <div class="space-y-4">
+            <p class="text-sm font-semibold text-gray-500">プレビュー</p>
+            <form class="space-y-4">
+                {% with label='ユーザー名', name='catalog-username', placeholder='山田太郎', required=true %}
+                    {% include 'molecules/form-group.html' %}
+                {% endwith %}
+                {% with label='メールアドレス', name='catalog-email', type='email', placeholder='you@example.com', help_text='通知を受け取るメールアドレス' %}
+                    {% include 'molecules/form-group.html' %}
+                {% endwith %}
+                {% with label='ユーザーID', name='catalog-id', value='ab', error='3文字以上で入力してください' %}
+                    {% include 'molecules/form-group.html' %}
+                {% endwith %}
+            </form>
+        </div>
+        <div class="bg-purple-50 rounded-2xl p-5 space-y-3">
+            <p class="font-semibold text-gray-800">バリエーション一覧</p>
+            <ul class="space-y-2 text-sm text-gray-600">
+                <li><span class="font-semibold text-gray-900">help_text:</span> エラーが無いときのみ補足を表示。</li>
+                <li><span class="font-semibold text-gray-900">error:</span> 入力直後にエラーテキストと赤ボーダーを自動適用。</li>
+                <li><span class="font-semibold text-gray-900">htmx:</span> 内部でAtoms/inputを利用しているため、hx-*属性をそのまま渡せます。</li>
+            </ul>
+        </div>
+    </div>
+
+    <div class="border border-slate-200 rounded-2xl overflow-hidden">
+        <button class="w-full flex items-center justify-between px-5 py-3 text-sm font-semibold text-gray-700" @click="showCode = !showCode">
+            <span>コードスニペット</span>
+            <span x-text="showCode ? '−' : '+'"></span>
+        </button>
+        <div x-show="showCode" x-transition class="bg-slate-900 text-slate-50 text-sm">
+            <pre class="overflow-x-auto p-5"><code>{{ snippet|trim|e }}</code></pre>
+        </div>
+    </div>
+</div>

--- a/templates/catalog/components/organisms-loading-indicator.html
+++ b/templates/catalog/components/organisms-loading-indicator.html
@@ -1,0 +1,65 @@
+{% set snippet %}
+{% raw %}
+<div class="flex items-center gap-4">
+    {% with id='indicator-spinner', variant='spinner', text='Loading…' %}
+        {% include 'organisms/loading-indicator.html' %}
+    {% endwith %}
+    {% with id='indicator-dots', variant='dots' %}
+        {% include 'organisms/loading-indicator.html' %}
+    {% endwith %}
+</div>
+{% endraw %}
+{% endset %}
+
+<div class="space-y-8" x-data="{ showCode: false }">
+    <header class="space-y-2">
+        <p class="text-xs uppercase tracking-wide text-emerald-600">{{ component.category }} / {{ component.title }}</p>
+        <h2 class="text-3xl font-bold text-gray-900">ローディングインジケーター</h2>
+        <p class="text-gray-600">`hx-indicator`で紐付けるだけで、htmxリクエスト中に自動表示されるコンポーネント群です。</p>
+    </header>
+
+    <div class="grid gap-6 lg:grid-cols-2">
+        <div class="space-y-4">
+            <p class="text-sm font-semibold text-gray-500">プレビュー</p>
+            <div class="space-y-6">
+                <div class="flex items-center gap-4">
+                    {% with id='catalog-indicator-spinner', variant='spinner', text='Spinner variant' %}
+                        {% include 'organisms/loading-indicator.html' %}
+                    {% endwith %}
+                    {% with id='catalog-indicator-dots', variant='dots', text='Dots variant' %}
+                        {% include 'organisms/loading-indicator.html' %}
+                    {% endwith %}
+                    {% with id='catalog-indicator-bar', variant='bar', text='Bar variant' %}
+                        {% include 'organisms/loading-indicator.html' %}
+                    {% endwith %}
+                </div>
+                <div class="space-y-2">
+                    <p class="text-xs text-gray-500">htmx連携例</p>
+                    <div class="rounded-2xl border border-dashed border-emerald-200 p-4" hx-get="/api/demo/message" hx-target="#indicator-demo-result" hx-swap="innerHTML" hx-indicator="#catalog-indicator-dots">
+                        <button class="px-4 py-2 bg-emerald-600 text-white rounded-lg" type="button">メッセージ取得</button>
+                        <div id="indicator-demo-result" class="mt-3 text-sm text-gray-600">リクエスト結果がここに表示されます。</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="bg-emerald-50 rounded-2xl p-5 space-y-3">
+            <p class="font-semibold text-gray-800">バリエーション一覧</p>
+            <ul class="space-y-2 text-sm text-gray-600">
+                <li><span class="font-semibold text-gray-900">spinner:</span> 一般的な円形ローダー。</li>
+                <li><span class="font-semibold text-gray-900">dots:</span> 小さなドットアニメーション。</li>
+                <li><span class="font-semibold text-gray-900">bar:</span> プログレスバー風の表示。</li>
+                <li><span class="font-semibold text-gray-900">text:</span> 任意の補足メッセージを添えられます。</li>
+            </ul>
+        </div>
+    </div>
+
+    <div class="border border-slate-200 rounded-2xl overflow-hidden">
+        <button class="w-full flex items-center justify-between px-5 py-3 text-sm font-semibold text-gray-700" @click="showCode = !showCode">
+            <span>コードスニペット</span>
+            <span x-text="showCode ? '−' : '+'"></span>
+        </button>
+        <div x-show="showCode" x-transition class="bg-slate-900 text-slate-50 text-sm">
+            <pre class="overflow-x-auto p-5"><code>{{ snippet|trim|e }}</code></pre>
+        </div>
+    </div>
+</div>

--- a/templates/catalog/components/organisms-modal.html
+++ b/templates/catalog/components/organisms-modal.html
@@ -1,0 +1,97 @@
+{% set snippet %}
+{% raw %}
+{% set modal_body %}
+    <div id="catalog-modal-content">
+        <p class="text-gray-500">アクションを選択するとここに差し込まれます。</p>
+    </div>
+{% endset %}
+{% with id='catalog-modal', title='サンプルモーダル', size='lg', body_content=modal_body %}
+    {% include 'organisms/modal.html' %}
+{% endwith %}
+<button
+    class="px-4 py-2 bg-blue-600 text-white rounded-lg"
+    hx-get="/api/organisms/modal/overview"
+    hx-target="#catalog-modal-content"
+    hx-swap="innerHTML"
+    @click="$dispatch('open-modal', { id: 'catalog-modal' })"
+>
+    概要を見る
+</button>
+{% endraw %}
+{% endset %}
+
+<div class="space-y-8" x-data="{ showCode: false }">
+    <header class="space-y-2">
+        <p class="text-xs uppercase tracking-wide text-emerald-600">{{ component.category }} / {{ component.title }}</p>
+        <h2 class="text-3xl font-bold text-gray-900">htmx対応モーダル</h2>
+        <p class="text-gray-600">`open-modal`イベントで開閉し、`hx-target`をモーダル内部の領域に設定して差し替えます。</p>
+    </header>
+
+    <div class="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+        <div class="space-y-4">
+            <p class="text-sm font-semibold text-gray-500">プレビュー</p>
+            <div class="flex flex-wrap gap-3">
+                <button
+                    class="px-4 py-2 rounded-lg border border-gray-200 hover:border-blue-500 hover:text-blue-600"
+                    hx-get="/api/organisms/modal/overview"
+                    hx-target="#catalog-modal-body"
+                    hx-swap="innerHTML"
+                    hx-indicator="#catalog-modal-indicator"
+                    @click="$dispatch('open-modal', { id: 'catalog-modal' })"
+                >
+                    プロジェクト概要
+                </button>
+                <button
+                    class="px-4 py-2 rounded-lg border border-gray-200 hover:border-blue-500 hover:text-blue-600"
+                    hx-get="/api/organisms/modal/release"
+                    hx-target="#catalog-modal-body"
+                    hx-swap="innerHTML"
+                    hx-indicator="#catalog-modal-indicator"
+                    @click="$dispatch('open-modal', { id: 'catalog-modal' })"
+                >
+                    リリースノート
+                </button>
+                <button
+                    class="px-4 py-2 rounded-lg border border-gray-200 hover:border-blue-500 hover:text-blue-600"
+                    hx-get="/api/organisms/modal/feedback"
+                    hx-target="#catalog-modal-body"
+                    hx-swap="innerHTML"
+                    hx-indicator="#catalog-modal-indicator"
+                    @click="$dispatch('open-modal', { id: 'catalog-modal' })"
+                >
+                    フィードバック
+                </button>
+            </div>
+            {% set modal_body %}
+                <div id="catalog-modal-body" class="space-y-3 text-gray-600">
+                    <p class="text-gray-500">左のアクションを選ぶとコンテンツを読み込みます。</p>
+                </div>
+                {% with id='catalog-modal-indicator', variant='spinner', text='読み込み中', class='justify-center text-sm text-gray-600 gap-2 mt-2' %}
+                    {% include 'organisms/loading-indicator.html' %}
+                {% endwith %}
+            {% endset %}
+            {% with id='catalog-modal', title='サーバー連携モーダル', size='lg', body_content=modal_body %}
+                {% include 'organisms/modal.html' %}
+            {% endwith %}
+        </div>
+        <div class="bg-emerald-50 rounded-2xl p-5 space-y-3">
+            <p class="font-semibold text-gray-800">バリエーション一覧</p>
+            <ul class="space-y-2 text-sm text-gray-600">
+                <li><span class="font-semibold text-gray-900">size:</span> sm/md/lg/xlの4段階。</li>
+                <li><span class="font-semibold text-gray-900">body_content / caller:</span> ボディをスロットとして挿入可能。</li>
+                <li><span class="font-semibold text-gray-900">show_footer:</span> フッターを非表示にしてカスタムアクションを作成。</li>
+                <li><span class="font-semibold text-gray-900">htmx:</span> モーダルを閉じずに`hx-target`エリアのみを更新。</li>
+            </ul>
+        </div>
+    </div>
+
+    <div class="border border-slate-200 rounded-2xl overflow-hidden">
+        <button class="w-full flex items-center justify-between px-5 py-3 text-sm font-semibold text-gray-700" @click="showCode = !showCode">
+            <span>コードスニペット</span>
+            <span x-text="showCode ? '−' : '+'"></span>
+        </button>
+        <div x-show="showCode" x-transition class="bg-slate-900 text-slate-50 text-sm">
+            <pre class="overflow-x-auto p-5"><code>{{ snippet|trim|e }}</code></pre>
+        </div>
+    </div>
+</div>

--- a/templates/catalog/components/organisms-navbar.html
+++ b/templates/catalog/components/organisms-navbar.html
@@ -1,0 +1,43 @@
+{% set snippet %}
+{% raw %}
+{% with brand_text='Design System', current_page='catalog' %}
+    {% include 'organisms/navbar.html' %}
+{% endwith %}
+{% endraw %}
+{% endset %}
+
+<div class="space-y-8" x-data="{ showCode: false }">
+    <header class="space-y-2">
+        <p class="text-xs uppercase tracking-wide text-emerald-600">{{ component.category }} / {{ component.title }}</p>
+        <h2 class="text-3xl font-bold text-gray-900">レスポンシブナビゲーション</h2>
+        <p class="text-gray-600">Alpine.jsでモバイルメニューを制御し、現在ページに応じたアクティブスタイルを自動的に付与します。</p>
+    </header>
+
+    <div class="space-y-4">
+        <p class="text-sm font-semibold text-gray-500">プレビュー</p>
+        <div class="border rounded-2xl overflow-hidden shadow-sm">
+            {% with brand_text='Design System', current_page='catalog' %}
+                {% include 'organisms/navbar.html' %}
+            {% endwith %}
+        </div>
+    </div>
+
+    <div class="bg-emerald-50 rounded-2xl p-5 space-y-3">
+        <p class="font-semibold text-gray-800">バリエーション一覧</p>
+        <ul class="space-y-2 text-sm text-gray-600">
+            <li><span class="font-semibold text-gray-900">brand_text / brand_url:</span> ロゴテキストとリンク先を差し替え可能。</li>
+            <li><span class="font-semibold text-gray-900">current_page:</span> ホバー/アクティブ状態をTailwindクラスで切り替え。</li>
+            <li><span class="font-semibold text-gray-900">モバイル:</span> Alpineの`mobileMenuOpen`でハンバーガーメニューを制御。</li>
+        </ul>
+    </div>
+
+    <div class="border border-slate-200 rounded-2xl overflow-hidden">
+        <button class="w-full flex items-center justify-between px-5 py-3 text-sm font-semibold text-gray-700" @click="showCode = !showCode">
+            <span>コードスニペット</span>
+            <span x-text="showCode ? '−' : '+'"></span>
+        </button>
+        <div x-show="showCode" x-transition class="bg-slate-900 text-slate-50 text-sm">
+            <pre class="overflow-x-auto p-5"><code>{{ snippet|trim|e }}</code></pre>
+        </div>
+    </div>
+</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -44,6 +44,9 @@
                     <a href="/organisms" class="inline-flex items-center px-6 py-3 bg-gradient-to-r from-emerald-600 to-emerald-700 text-white font-medium rounded-lg shadow-md hover:from-emerald-700 hover:to-emerald-800 transition-all">
                         Organisms →
                     </a>
+                    <a href="/catalog" class="inline-flex items-center px-6 py-3 bg-gradient-to-r from-rose-500 to-orange-500 text-white font-medium rounded-lg shadow-md hover:from-rose-600 hover:to-orange-600 transition-all">
+                        Catalog →
+                    </a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary\n- add /catalog route that lists every Atom/Molecule/Organism with htmx-driven detail panel\n- introduce reusable metadata + partial templates to render demos, variations, and code snippets\n- expose the new catalog entry point via navbar/home links\n\n## Testing\n- python3 -m py_compile app.py\n\nCloses #6