### PR TITLE
feat: add practical use case demos

### DIFF
--- a/components/organisms/navbar.html
+++ b/components/organisms/navbar.html
@@ -53,6 +53,13 @@
             Organisms
           </a>
           <a
+            href="/use-cases"
+            class="px-3 py-2 rounded-md text-sm font-medium transition
+              {% if current_page == 'use-cases' %}bg-blue-100 text-blue-700{% else %}text-gray-700 hover:bg-gray-100{% endif %}"
+          >
+            Use Cases
+          </a>
+          <a
             href="/catalog"
             class="px-3 py-2 rounded-md text-sm font-medium transition
               {% if current_page == 'catalog' %}bg-blue-100 text-blue-700{% else %}text-gray-700 hover:bg-gray-100{% endif %}"
@@ -107,6 +114,13 @@
           {% if current_page == 'organisms' %}bg-blue-100 text-blue-700{% else %}text-gray-700 hover:bg-gray-100{% endif %}"
       >
         Organisms
+      </a>
+      <a
+        href="/use-cases"
+        class="block px-3 py-2 rounded-md text-base font-medium transition
+          {% if current_page == 'use-cases' %}bg-blue-100 text-blue-700{% else %}text-gray-700 hover:bg-gray-100{% endif %}"
+      >
+        Use Cases
       </a>
       <a
         href="/catalog"

--- a/templates/index.html
+++ b/templates/index.html
@@ -44,6 +44,9 @@
                     <a href="/organisms" class="inline-flex items-center px-6 py-3 bg-gradient-to-r from-emerald-600 to-emerald-700 text-white font-medium rounded-lg shadow-md hover:from-emerald-700 hover:to-emerald-800 transition-all">
                         Organisms →
                     </a>
+                    <a href="/use-cases" class="inline-flex items-center px-6 py-3 bg-gradient-to-r from-slate-900 to-slate-700 text-white font-medium rounded-lg shadow-md hover:from-slate-800 hover:to-slate-600 transition-all">
+                        Use Cases →
+                    </a>
                     <a href="/catalog" class="inline-flex items-center px-6 py-3 bg-gradient-to-r from-rose-500 to-orange-500 text-white font-medium rounded-lg shadow-md hover:from-rose-600 hover:to-orange-600 transition-all">
                         Catalog →
                     </a>

--- a/templates/use-cases.html
+++ b/templates/use-cases.html
@@ -1,0 +1,173 @@
+{% extends "base.html" %}
+
+{% block title %}Use Cases - htmx Design System PoC{% endblock %}
+
+{% block content %}
+<div class="bg-slate-100">
+    <div class="container mx-auto px-4 py-10 space-y-12">
+        <header class="space-y-4 text-center">
+            <p class="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 uppercase tracking-[0.3em]">
+                Practical Scenarios
+                <span class="h-1.5 w-1.5 rounded-full bg-blue-500"></span>
+                htmx + Design System
+            </p>
+            <h1 class="text-4xl font-bold text-gray-900">実践ユースケース集</h1>
+            <p class="max-w-3xl mx-auto text-gray-600">
+                動的リスト更新、フォーム送信、モーダル詳細表示、エラーハンドリングなど実務に近いフローを
+                htmxとデザインシステムのコンポーネントでどう表現するかを示します。
+            </p>
+        </header>
+
+        <section class="grid gap-8 lg:grid-cols-[1.1fr_0.9fr] bg-white rounded-3xl shadow-sm p-8">
+            <div class="space-y-6">
+                <div class="space-y-2">
+                    <p class="text-sm font-semibold text-blue-600">Use Case 01</p>
+                    <h2 class="text-2xl font-bold text-gray-900">バックログの動的更新</h2>
+                    <p class="text-gray-600">タスクを追加・削除し、モーダルで詳細を確認。`hx-target`でリスト部分のみを差し替えます。</p>
+                </div>
+
+                <form
+                    class="bg-slate-50 rounded-2xl p-5 space-y-4"
+                    hx-post="/api/use-cases/tasks"
+                    hx-target="#task-panel"
+                    hx-swap="outerHTML"
+                    hx-indicator="#task-panel-indicator"
+                >
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">タスク名</label>
+                        <input type="text" name="title" class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:ring-2 focus:ring-blue-500" placeholder="例: モーダルUX改善" required>
+                    </div>
+                    <div class="grid gap-4 md:grid-cols-2">
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 mb-1">担当</label>
+                            <input type="text" name="owner" class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:ring-2 focus:ring-blue-500" placeholder="DesignOps">
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 mb-1">ステータス</label>
+                            <select name="status" class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:ring-2 focus:ring-blue-500">
+                                {% for key, meta in status_meta.items() %}
+                                    <option value="{{ key }}">{{ meta.label }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">概要</label>
+                        <textarea name="summary" rows="3" class="w-full rounded-xl border border-gray-300 px-3 py-2 focus:ring-2 focus:ring-blue-500" placeholder="タスクの背景や期待成果"></textarea>
+                    </div>
+                    <div class="flex items-center gap-3">
+                        {% with text='タスクを追加', variant='primary' %}
+                            {% include 'atoms/button.html' %}
+                        {% endwith %}
+                        {% with id='task-panel-indicator', variant='spinner', text='更新中...', class='text-sm text-gray-600 gap-2' %}
+                            {% include 'organisms/loading-indicator.html' %}
+                        {% endwith %}
+                    </div>
+                </form>
+            </div>
+
+            <div>
+                {% include 'use_cases/partials/task_panel.html' with context %}
+            </div>
+        </section>
+
+        <section class="grid gap-8 lg:grid-cols-2">
+            <div class="bg-white rounded-3xl shadow-sm p-8 space-y-6">
+                <div class="space-y-2">
+                    <p class="text-sm font-semibold text-purple-600">Use Case 02</p>
+                    <h2 class="text-2xl font-bold text-gray-900">フォーム送信とバリデーション</h2>
+                    <p class="text-gray-600">Server-sideで入力値を検証し、エラー/成功メッセージを同じ領域に差し替えます。</p>
+                </div>
+
+                <form
+                    class="space-y-4"
+                    hx-post="/api/use-cases/feedback"
+                    hx-target="#feedback-result"
+                    hx-swap="innerHTML"
+                    hx-indicator="#feedback-indicator"
+                >
+                    {% with label='お名前', name='name', placeholder='山田太郎', required=true %}
+                        {% include 'molecules/form-group.html' %}
+                    {% endwith %}
+                    {% with label='メールアドレス', name='email', type='email', placeholder='you@example.com', required=true %}
+                        {% include 'molecules/form-group.html' %}
+                    {% endwith %}
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 mb-1">フィードバック</label>
+                        <textarea name="message" rows="4" class="w-full rounded-xl border border-gray-300 px-3 py-2 focus:ring-2 focus:ring-purple-500" placeholder="10文字以上で入力してください" required></textarea>
+                    </div>
+                    <div class="flex items-center gap-3">
+                        {% with text='送信', variant='primary' %}
+                            {% include 'atoms/button.html' %}
+                        {% endwith %}
+                        {% with id='feedback-indicator', variant='dots', text='送信中...', class='text-sm text-gray-500 gap-2' %}
+                            {% include 'organisms/loading-indicator.html' %}
+                        {% endwith %}
+                    </div>
+                </form>
+
+                <div id="feedback-result" class="rounded-2xl border border-dashed border-purple-200 bg-purple-50/50 p-4 text-sm text-gray-500">
+                    フォームを送信するとここに結果が表示されます。
+                </div>
+            </div>
+
+            <div class="bg-white rounded-3xl shadow-sm p-8 space-y-6">
+                <div class="space-y-2">
+                    <p class="text-sm font-semibold text-rose-600">Use Case 03</p>
+                    <h2 class="text-2xl font-bold text-gray-900">エラーハンドリングパターン</h2>
+                    <p class="text-gray-600">HTTPステータスに応じたUIを描画し、500/504などのケースでもユーザーに状況を伝えます。</p>
+                </div>
+
+                <div class="flex flex-wrap gap-3">
+                    <button
+                        class="px-4 py-2 rounded-lg border border-gray-200 hover:border-emerald-400"
+                        hx-get="/api/use-cases/error-demo?mode=success"
+                        hx-target="#error-demo-panel"
+                        hx-swap="innerHTML"
+                        hx-indicator="#error-demo-indicator"
+                    >
+                        正常レスポンス
+                    </button>
+                    <button
+                        class="px-4 py-2 rounded-lg border border-gray-200 hover:border-amber-400"
+                        hx-get="/api/use-cases/error-demo?mode=timeout"
+                        hx-target="#error-demo-panel"
+                        hx-swap="innerHTML"
+                        hx-indicator="#error-demo-indicator"
+                    >
+                        タイムアウト想定
+                    </button>
+                    <button
+                        class="px-4 py-2 rounded-lg border border-red-200 text-red-600 hover:border-red-400"
+                        hx-get="/api/use-cases/error-demo?mode=server-error"
+                        hx-target="#error-demo-panel"
+                        hx-swap="innerHTML"
+                        hx-indicator="#error-demo-indicator"
+                    >
+                        サーバーエラー再現
+                    </button>
+                </div>
+
+                <div id="error-demo-panel" class="rounded-2xl border border-dashed border-rose-200 bg-rose-50/60 p-4 text-sm text-gray-600">
+                    ボタンを押すとレスポンス内容とHTTPステータスに応じたUIが挿入されます。
+                </div>
+                {% with id='error-demo-indicator', variant='spinner', text='処理中...', class='text-sm text-gray-500 gap-2' %}
+                    {% include 'organisms/loading-indicator.html' %}
+                {% endwith %}
+            </div>
+        </section>
+    </div>
+</div>
+
+{% set modal_body %}
+    <div id="use-case-modal-body" class="space-y-4 text-gray-700">
+        <p class="text-gray-500">タスクカードの「詳細を見る」を押すと内容がここに表示されます。</p>
+    </div>
+    {% with id='use-case-modal-indicator', variant='spinner', text='ロード中...', class='justify-center text-sm text-gray-600 gap-2 mt-2' %}
+        {% include 'organisms/loading-indicator.html' %}
+    {% endwith %}
+{% endset %}
+{% with id='use-case-modal', title='タスク詳細', size='lg', body_content=modal_body %}
+    {% include 'organisms/modal.html' %}
+{% endwith %}
+{% endblock %}

--- a/templates/use_cases/partials/error_message.html
+++ b/templates/use_cases/partials/error_message.html
@@ -1,0 +1,9 @@
+{% set palette = {
+    'success': 'border-emerald-200 bg-emerald-50 text-emerald-800',
+    'warning': 'border-amber-200 bg-amber-50 text-amber-800',
+    'error': 'border-red-200 bg-red-50 text-red-800'
+}.get(level, 'border-slate-200 bg-slate-50 text-slate-800') %}
+<div class="rounded-2xl border px-4 py-3 space-y-1 text-sm {{ palette }}">
+    <p class="font-semibold">{{ title }}</p>
+    <p>{{ body }}</p>
+</div>

--- a/templates/use_cases/partials/feedback_response.html
+++ b/templates/use_cases/partials/feedback_response.html
@@ -1,0 +1,8 @@
+{% set color = {
+    'success': 'bg-emerald-50 border-emerald-200 text-emerald-700',
+    'error': 'bg-red-50 border-red-200 text-red-700'
+}.get(level, 'bg-blue-50 border-blue-200 text-blue-700') %}
+<div class="rounded-2xl border px-4 py-3 space-y-1 text-sm {{ color }}">
+    <p class="font-semibold">{{ title }}</p>
+    <p>{{ body }}</p>
+</div>

--- a/templates/use_cases/partials/task_detail.html
+++ b/templates/use_cases/partials/task_detail.html
@@ -1,0 +1,22 @@
+{% if not task %}
+<div class="space-y-2">
+    <p class="text-gray-600 text-sm">タスクが選択されていません。</p>
+</div>
+{% else %}
+    {% set meta = status_meta.get(task.status, status_meta['planning']) %}
+    <div class="space-y-4">
+        <div class="space-y-2">
+            <div class="flex items-center gap-3">
+                <h3 class="text-2xl font-bold text-gray-900">{{ task.title }}</h3>
+                <span class="inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold {{ meta.badge_class }}">
+                    {{ meta.label }}
+                </span>
+            </div>
+            <p class="text-sm text-gray-500">Owner: {{ task.owner }}</p>
+        </div>
+        <p class="text-gray-700 leading-relaxed">{{ task.details }}</p>
+        <div class="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-gray-600">
+            <p>htmxリクエストでモーダル内部のみを差し替えています。モーダル自体は開いたままで、`hx-target="#use-case-modal-body"` が指している領域だけが更新されます。</p>
+        </div>
+    </div>
+{% endif %}

--- a/templates/use_cases/partials/task_panel.html
+++ b/templates/use_cases/partials/task_panel.html
@@ -1,0 +1,58 @@
+<div id="task-panel" class="space-y-4">
+    {% if flash %}
+        {% set flash_class = {
+            'success': 'bg-emerald-50 text-emerald-700 border-emerald-200',
+            'info': 'bg-blue-50 text-blue-700 border-blue-200',
+            'error': 'bg-red-50 text-red-700 border-red-200'
+        }.get(flash.level, 'bg-slate-50 text-slate-700 border-slate-200') %}
+        <div class="rounded-2xl border px-4 py-3 text-sm font-medium {{ flash_class }}">
+            {{ flash.message }}
+        </div>
+    {% endif %}
+
+    <div class="space-y-3">
+        {% for task in tasks %}
+            {% set meta = status_meta.get(task.status, status_meta['planning']) %}
+            <div class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+                <div class="flex items-start justify-between gap-4">
+                    <div class="space-y-2">
+                        <div class="flex items-center gap-3 flex-wrap">
+                            <p class="text-lg font-semibold text-gray-900">{{ task.title }}</p>
+                            <span class="inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold {{ meta.badge_class }}">
+                                {{ meta.label }}
+                            </span>
+                        </div>
+                        <p class="text-sm text-gray-600">{{ task.summary }}</p>
+                        <p class="text-xs text-gray-400">Owner: {{ task.owner }}</p>
+                    </div>
+                    <div class="flex flex-col gap-2">
+                        <button
+                            class="px-3 py-2 rounded-lg border border-gray-200 text-sm text-gray-700 hover:border-blue-400"
+                            hx-get="/api/use-cases/tasks/{{ task.id }}/detail"
+                            hx-target="#use-case-modal-body"
+                            hx-swap="innerHTML"
+                            hx-indicator="#use-case-modal-indicator"
+                            @click="$dispatch('open-modal', { id: 'use-case-modal' })"
+                            type="button"
+                        >
+                            詳細を見る
+                        </button>
+                        <button
+                            class="px-3 py-2 rounded-lg border border-gray-200 text-sm text-red-600 hover:border-red-400"
+                            hx-delete="/api/use-cases/tasks/{{ task.id }}"
+                            hx-target="#task-panel"
+                            hx-swap="outerHTML"
+                            hx-indicator="#task-panel-indicator"
+                            hx-confirm="このタスクを削除しますか？"
+                            type="button"
+                        >
+                            削除
+                        </button>
+                    </div>
+                </div>
+            </div>
+        {% else %}
+            <p class="text-sm text-gray-500">タスクがありません。左のフォームから追加してください。</p>
+        {% endfor %}
+    </div>
+</div>


### PR DESCRIPTION
## Summary\n- introduce /use-cases page showcasing dynamic backlog management, forms, modal detail, and error handling\n- add supporting Flask endpoints for task CRUD, feedback validation, and error simulation\n- expose the page via navbar/home links\n\n## Testing\n- python3 -m py_compile app.py\n\nCloses #7