### PR TITLE
docs: add project guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# htmx Design System PoC
+
+Server-rendered design system playground that combines Flask, Tailwind CSS, Alpine.js, and htmx. The project demonstrates how to structure reusable HTML components (Atoms → Molecules → Organisms), expose them through an interactive catalog, and showcase practical htmx-powered workflows.
+
+## Features
+- **Component catalogs**: Dedicated pages for Atoms, Molecules, Organisms, and an aggregated `/catalog` explorer that streams live snippets into the detail panel via `hx-get`/`hx-swap`.
+- **Practical use cases**: `/use-cases` illustrates backlog management, modal details, form validation, and error-handling flows driven by htmx.
+- **Reusable partials**: Components live under `components/` and can be included across templates with a consistent API.
+- **API demos**: Flask endpoints under `/api/*` respond with HTML fragments optimized for htmx swaps.
+
+## Stack
+- Python 3.11+
+- Flask 3.0
+- htmx 2.0.3 (CDN)
+- Alpine.js 3.14 (CDN)
+- Tailwind CSS (CDN)
+
+## Getting Started
+1. **Install dependencies** (recommended: virtual environment)
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+2. **Run the development server**
+   ```bash
+   flask --app app.py run --debug
+   ```
+3. Visit `http://127.0.0.1:5000` and browse the catalog/use-case pages.
+
+### Helpful Commands
+- `python3 -m py_compile app.py` – quick syntax check
+- `FLASK_DEBUG=1 flask --app app.py run` – auto-reload on template/code changes
+
+## Project Layout
+```
+htmx-design-system-poc/
+├── app.py                     # Flask routes + demo APIs
+├── components/                # Reusable Jinja partials (atoms/molecules/organisms)
+├── templates/                 # Page templates + catalog/use-case partials
+├── static/                    # (Optional) assets bucket
+├── docs/                      # Guides (component usage, best practices, architecture)
+├── requirements.txt
+└── PLAN.md                    # Original exploration notes
+```
+
+Key pages:
+- `/` – landing page with quick links
+- `/atoms`, `/molecules`, `/organisms` – catalog by layer
+- `/catalog` – single-screen explorer with code snippets
+- `/use-cases` – realistic workflows (task CRUD, form validation, error responses)
+
+## Documentation
+Additional guides live under `docs/`:
+- [`docs/component-guide.md`](docs/component-guide.md) – how to compose atoms/molecules/organisms
+- [`docs/best-practices.md`](docs/best-practices.md) – recommended patterns for htmx + Flask
+- [`docs/architecture.md`](docs/architecture.md) – route topology and data flow diagram
+
+## Contributing
+1. Create a feature branch per GitHub Issue.
+2. Follow conventional commits (`feat:`, `fix:`, `docs:` ...).
+3. Open a PR via `gh pr create` and link the issue (e.g., `Closes #8`).
+
+## License
+[MIT](LICENSE)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,44 @@
+# Architecture Overview
+
+## High-Level Flow
+```mermaid
+flowchart LR
+    Browser((Browser)) -->|htmx requests| Flask[Flask Routes]
+    Flask --> Templates[Jinja Templates]
+    Templates --> Components[Atoms / Molecules / Organisms]
+    Flask --> APIs[/API Endpoints (/api/*)/]
+    APIs --> Templates
+    Browser -->|Alpine events| Components
+```
+
+- **Browser**: renders server-sent HTML, triggers htmx attributes for partial updates, and dispatches Alpine events (`open-modal`).
+- **Flask Routes**: `/`, `/atoms`, `/molecules`, `/organisms`, `/catalog`, `/use-cases` deliver full pages.
+- **API Endpoints**: `/api/catalog/<slug>`, `/api/use-cases/*`, `/api/demo/*`, etc., return HTML fragments that slot back into the DOM.
+- **Templates & Components**: Jinja renders `components/` partials, keeping the design system consistent.
+
+## Key Modules
+| Module | Responsibility |
+|--------|----------------|
+| `app.py` | Routing layer, htmx-friendly endpoints, metadata registries (`CATALOG_COMPONENTS`, `USE_CASE_TASKS`). |
+| `components/` | Atomic HTML snippets parameterized via Jinja. |
+| `templates/catalog/components/` | Showcase snippets loaded dynamically by `/catalog`. |
+| `templates/use_cases/partials/` | Server-rendered fragments for backlog, modals, feedback, and error states. |
+
+## Request Examples
+1. **Catalog Detail**
+   - User clicks a component → button issues `hx-get="/api/catalog/atoms-button"`.
+   - Flask renders `templates/catalog/components/atoms-button.html`.
+   - htmx swaps the detail panel with the returned HTML; indicator hides automatically.
+
+2. **Use-Case Task Add/Delete**
+   - Form posts to `/api/use-cases/tasks` → server mutates `USE_CASE_TASKS` and rerenders `task_panel.html`.
+   - Delete button issues `hx-delete` to the same endpoint and replaces the panel with the updated snippet.
+
+3. **Modal Detail**
+   - `hx-get="/api/use-cases/tasks/<id>/detail"` targets `#use-case-modal-body` inside an open modal.
+   - Alpine keeps the modal visible while only the body content changes.
+
+## Deployment Considerations
+- Serve via Gunicorn/uwsgi behind Nginx for production.
+- Cache static assets (`static/`) and consider extracting CDN scripts if operating offline.
+- External services are unnecessary; all data is in-memory for PoC purposes, but replacing collections with a database only requires adapting helper functions such as `find_task`.

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -1,0 +1,32 @@
+# Best Practices
+
+## 1. Template Composition
+- Prefer small partials (`components/atoms/*`) and pass data via `with context` to keep templates declarative.
+- Use `body_content` or `caller()` slots for larger organisms (e.g., modals) to avoid deeply nested conditionals.
+- Keep Tailwind class decisions close to the component so consumers only flip semantic props such as `variant` or `status`.
+
+## 2. htmx Patterns
+- **Explicit targets**: every `hx-get`/`hx-post` must declare `hx-target`/`hx-swap` to avoid unexpected DOM replacements.
+- **Indicators**: pair requests with `hx-indicator="#loading-id"` and reuse `components/organisms/loading-indicator.html` for consistent UX.
+- **Confirm + delete**: set `hx-confirm` on destructive actions and aim responses at the same region (`hx-target="#task-panel"`).
+- **Error codes matter**: return 4xx for validation errors, 5xx for server issues—htmx exposes status codes for `hx-on:error` hooks if needed.
+
+## 3. Flask Responses
+- Return HTML fragments, not JSON, unless the client explicitly expects data transformation.
+- Keep response templates under `templates/use_cases/partials/` (or similar) for easy server-side testing.
+- Use helper functions (e.g., `render_task_panel`) to centralize repeated markup + flash messaging logic.
+
+## 4. Accessibility & UX
+- Labels must reference inputs via `for`/`id` attributes; the `form-group` molecule already wires this up.
+- When feeding modals, dispatch `open-modal`/`close-modal` events via Alpine so focus trapping stays intact.
+- Provide textual alternatives for indicators (`text` prop) and always describe success/error states with color + text.
+
+## 5. State Management
+- Treat server-side lists (`USE_CASE_TASKS`) as the source of truth; do not mutate them from the client without a round-trip.
+- For optimistic UI, return the updated snippet immediately so the user sees confirmation without a full reload.
+
+## 6. Deployment Notes
+- Behind a production web server, set `FLASK_ENV=production` and ensure `SECRET_KEY` is configured.
+- Consider extracting component metadata (for `/catalog`) into JSON/Markdown if non-developers need to contribute.
+
+Following these practices keeps the htmx + Flask flow predictable while maintaining a design-system mindset.

--- a/docs/component-guide.md
+++ b/docs/component-guide.md
@@ -1,0 +1,72 @@
+# Component Usage Guide
+
+This project treats each HTML partial as a reusable building block. Compose them like LEGO bricks using Jinja’s `include`/`with` statements.
+
+## Atoms
+Location: `components/atoms/`
+
+| Component | Purpose | Key Params |
+|-----------|---------|------------|
+| `button.html` | Tailwind-styled button with htmx hooks | `text`, `variant`, `size`, `hx-*` |
+| `input.html` | Accessible input with error state | `name`, `type`, `placeholder`, `error`, `hx-*` |
+| `label.html` | Form label with optional required mark | `text`, `for`, `required` |
+| `text.html` | Typographic token (heading, caption, status) | `content`, `variant` |
+
+Example:
+```jinja
+{% with text='Save', variant='primary', hx_post='/api/save', hx_target='#result' %}
+  {% include 'atoms/button.html' %}
+{% endwith %}
+```
+
+## Molecules
+Location: `components/molecules/`
+
+- `form-group.html` wraps `atoms/label` + `atoms/input`, handling help/error messaging automatically.
+- `card.html` renders media, copy, and optional footer actions. Add `variant='clickable'` plus `hx-get` to stream detail panes.
+
+Example form section:
+```jinja
+{% with label='ユーザー名', name='username', placeholder='山田太郎', required=true %}
+  {% include 'molecules/form-group.html' %}
+{% endwith %}
+```
+
+## Organisms
+Location: `components/organisms/`
+
+| Component | Highlights |
+|-----------|------------|
+| `navbar.html` | Responsive navigation with Alpine-powered mobile menu. Pass `current_page` to highlight tabs. |
+| `modal.html` | Alpine-driven modal shell. Provide `id`, `title`, and `body_content` or a `caller()` block. Use `hx-target` inside the modal body to stream content. |
+| `loading-indicator.html` | Reusable `hx-indicator` companion (`spinner`, `dots`, or `bar`). |
+
+Modal usage:
+```jinja
+{% set modal_body %}
+  <div id="detail-body">ロード待ち...</div>
+{% endset %}
+{% with id='detail-modal', title='詳細', size='lg', body_content=modal_body %}
+  {% include 'organisms/modal.html' %}
+{% endwith %}
+```
+Then trigger from any element:
+```html
+<button hx-get="/api/tasks/42" hx-target="#detail-body" @click="$dispatch('open-modal', { id: 'detail-modal' })">
+  詳細を見る
+</button>
+```
+
+## Catalog Integration
+`/catalog` uses `app.py`’s `CATALOG_COMPONENTS` metadata to load partials dynamically. To add a new component preview:
+1. Create a template under `templates/catalog/components/<name>.html`.
+2. Register its metadata in `CATALOG_COMPONENTS` with `slug`, `title`, `category`, `summary`, and template path.
+3. The detail pane will automatically fetch `/api/catalog/<slug>`.
+
+## Use Case Components
+The `/use-cases` page relies on:
+- `use_cases/partials/task_panel.html` for backlog management.
+- `use_cases/partials/task_detail.html` for modal content.
+- `use_cases/partials/feedback_response.html` and `error_message.html` for form/error feedback.
+
+Reuse these partials whenever you need consistent UI for CRUD lists, modals, or flash messaging.


### PR DESCRIPTION
## Summary\n- add README with setup, stack, and navigation pointers\n- create docs for component usage, best practices, and architecture overview (mermaid diagram)\n- link the new docs from the README to satisfy Issue #8\n\n## Testing\n- not required (docs only)\n\nCloses #8